### PR TITLE
Fix JSON object/array. Add "method" return parameter.

### DIFF
--- a/components/dlink_tcp/src/connection.erl
+++ b/components/dlink_tcp/src/connection.erl
@@ -216,7 +216,6 @@ handle_info({tcp, Sock, Data},
 	    #st { ip = undefined } = St) ->
     {ok, {IP, Port}} = inet:peername(Sock),
     NSt = St#st { ip = inet_parse:ntoa(IP), port = Port },
-    ?warning("YESSSS"),
     handle_info({tcp, Sock, Data}, NSt);
  
 

--- a/components/proto_json/src/proto_json_rpc.erl
+++ b/components/proto_json/src/proto_json_rpc.erl
@@ -127,7 +127,7 @@ handle_call({rvi, send_message,
 			  [
 			   { "service", ServiceName },
 			   { "timeout", Timeout }, 
-			   { "parameters", {array, Parameters} },
+			   { "parameters", Parameters },
 			   { "signature", Signature }
 			  ]
 			}),
@@ -148,7 +148,7 @@ handle_cast({rvi, receive_message, [Payload, IP, Port]}, St) when is_binary(Payl
 handle_cast({rvi, receive_message, [Payload, IP, Port]}, St) ->
     {ok, {struct, Elems}} = exo_json:decode_string(Payload),
 
-    [ ServiceName, Timeout, {array, Parameters}, Signature ] = 
+    [ ServiceName, Timeout, Parameters, Signature ] = 
 	opts(["service", "timeout", "parameters", "signature"], Elems, undefined),
 
     ?debug("    protocol:rcv(): service name:    ~p~n", [ServiceName]),

--- a/components/schedule/src/schedule_rpc.erl
+++ b/components/schedule/src/schedule_rpc.erl
@@ -130,7 +130,7 @@ schedule_message(CompSpec,
 		       schedule_message, 
 		       [{ service, SvcName }, 
 			{ timeout, Timeout },
-			{ parameters, Parameters }, 
+			{ parameters, {struct, Parameters } }, 
 			{ signature, Signature }], 
 		       [status, transaction_id], CompSpec).
 

--- a/components/service_edge/src/service_edge_rpc.erl
+++ b/components/service_edge/src/service_edge_rpc.erl
@@ -183,6 +183,7 @@ handle_websocket(WSock, Mesg, Arg) ->
     ok.
 
 
+
 %% Websocket interface
 handle_ws_json_rpc(WSock, "message", Params, _Arg ) ->
     { ok, SvcName } = rvi_common:get_json_element(["service_name"], Params),
@@ -198,7 +199,8 @@ handle_ws_json_rpc(WSock, "message", Params, _Arg ) ->
 
     ?debug("service_edge_rpc:wse_message(~p) Res:      ~p", [ WSock, Res ]),
     { ok, [ { status, rvi_common:json_rpc_status(Res) }, 
-	    { transaction_id, TID} ] };
+	    { transaction_id, TID},
+	    { method, "message"} ] };
 
 handle_ws_json_rpc(WSock, "register_service", Params,_Arg ) ->
     { ok, SvcName } = rvi_common:get_json_element(["service_name"], Params),
@@ -210,7 +212,8 @@ handle_ws_json_rpc(WSock, "register_service", Params,_Arg ) ->
 					     "ws:" ++ pid_to_list(WSock)]}),
     
     { ok, [ { status, rvi_common:json_rpc_status(ok)}, 
-	    { service, FullSvcName }]};
+	    { service, FullSvcName },
+	    { method, "register_service"}]};
 
 handle_ws_json_rpc(WSock, "unregister_service", Params, _Arg ) ->
     { ok, SvcName } = rvi_common:get_json_element(["service_name"], Params),
@@ -222,7 +225,8 @@ handle_ws_json_rpc(_Ws , "get_available_services", _Params, _Arg ) ->
     ?debug("service_edge_rpc:websocket_get_available()"),
     [ Services ] = gen_server:call(?SERVER, { rvi, get_available_services, []}),
     { ok, [ { status, rvi_common:json_rpc_status(ok)},
-	    { services, Services}] }.
+	    { services, Services},
+	    { method, "get_available_services"}] }.
 
 
 %% Invoked by locally connected services.
@@ -236,20 +240,27 @@ handle_rpc("register_service", Args) ->
 					 { rvi, register_local_service, 
 					   [ SvcName, URL]}),
 
-    {ok, [ {status, rvi_common:json_rpc_status(ok) }, { service, FullSvcName }]};
+    {ok, [ {status, rvi_common:json_rpc_status(ok) }, 
+	   { service, FullSvcName },
+	   { method, "register_service"} 
+	 ]};
 
 
 handle_rpc("unregister_service", Args) ->
     {ok, SvcName} = rvi_common:get_json_element(["service"], Args),
     gen_server:call(?SERVER, { rvi, unregister_local_service, [ SvcName]}),
-    {ok, [ { status, rvi_common:json_rpc_status(ok) }]};
+    {ok, [ { status, rvi_common:json_rpc_status(ok) },
+	   { method, "unregister_service"} 
+	 ]};
 
 
 handle_rpc("get_available_services", _Args) ->
     [ Status, Services ] = gen_server:call(?SERVER, { rvi, get_available_services, []}),
     ?debug("get_available_services(): ~p ~p", [ Status, Services ]),
     {ok, [ { status, rvi_common:json_rpc_status(ok)},
-	   { services, {array, Services}} ]};
+	   { services, {array, Services}},
+	   { method, "get_available_services"} 
+	 ]};
 
 
 handle_rpc("message", Args) ->
@@ -260,7 +271,9 @@ handle_rpc("message", Args) ->
 					      [ SvcName, Timeout, Parameters]}),
 
     {ok, [ { status, rvi_common:json_rpc_status(Res) },
-	   { transaction_id, TID } ]};
+	   { transaction_id, TID },
+	   { method, "message"} 
+	 ]};
 
 handle_rpc(Other, _Args) ->
     ?warning("service_edge_rpc:handle_rpc(~p): unknown command", [ Other ]),

--- a/python/rvi_call.py
+++ b/python/rvi_call.py
@@ -49,11 +49,11 @@ if len(args) < 1:
 # Construct a dictionary from the provided paths.
 i = 0
 service = args[0]
-rvi_args = []
+rvi_args = {}
 for i in args[1:]:
     print i
     [k, v] = i.split('=')
-    rvi_args = rvi_args + [{ k: v}]
+    rvi_args[k] = v
 
 
 

--- a/python/rvi_call_ws.py
+++ b/python/rvi_call_ws.py
@@ -1,0 +1,39 @@
+import websocket
+import time
+import sys
+import getopt
+import json
+
+opts, args = getopt.getopt(sys.argv[1:], "n:")
+
+host = 'ws://localhost:8808'
+
+for o, a in opts:
+    if o == "-n":
+        host = a
+    else:
+        usage()
+if len(args) < 1:
+    usage()
+
+i = 0
+service = args[0]
+rvi_args = {}
+for i in args[1:]:
+    print i
+    [k, v] = i.split('=')
+    rvi_args[k] = v
+
+ws = websocket.create_connection(host)
+
+print "RVI Node:         ", host
+print "Service:          ", service
+print "args:             ", rvi_args
+
+payload = {}
+payload['jsonrpc'] = "2.0"
+payload['params'] = {'service_name':service, 'timeout':(int(time.time())+60), 'parameters':rvi_args}
+payload['id'] = "1"
+payload['method'] = 'message'
+
+ws.send(json.dumps(payload))

--- a/python/rvi_service_ws.py
+++ b/python/rvi_service_ws.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2015, Jaguar Land Rover
+#
+# This program is licensed under the terms and conditions of the
+# Mozilla Public License, version 2.0.  The full text of the 
+# Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+#
+#
+# Register a service specified by command line with an RVI node.
+# Print out a message when the service gets invoked.
+#
+import sys
+from rvilib import RVI
+# pip-install websocket-client
+import websocket
+import json
+import getopt
+
+def usage():
+    print "Usage:", sys.argv[0], "[-n <rvi_url>] <service_name>"
+    print "  <rvi_url>                     URL of Service Edge on a local RVI node."
+    print "                                Default: ws://localhost:8808"
+    print "  <service_name>                URL of Service to register"
+    print
+    print "The Service Edge URL is logged as a notice when the"
+    print "RVI node is started."
+    print
+   
+    print "Example: ./rvi_service_ws.py -n ws://rvi1.nginfotpdx.net:8808 /test/some_service"
+    sys.exit(255)
+
+
+#
+# Our general handler, registered with rvi.register_service() below.
+#
+# You can also explicitly name the arguments, but then
+# the sender has to match the argument names.
+
+# For example:
+# rvi_call.py http://localhost:8801 jlr.com/vin/test a=1 b=2 c=3 ->
+#    def service(a,b,c)
+# 
+def service_invoked(**args):
+    print
+    print "Service invoked!"
+    print "args:", args 
+    print
+    sys.stdout.write("Press enter to quit: ")
+    sys.stdout.flush()
+    return ['ok']
+
+def services_available(**args):
+    print
+    print "Services available!"
+    print "args:", args 
+    print
+    sys.stdout.write("Press enter to quit: ")
+    sys.stdout.flush()
+    return ['ok']
+
+def services_unavailable(**args):
+    print
+    print "Services unavailable!"
+    print "args:", args 
+    print
+    sys.stdout.write("Press enter to quit: ")
+    sys.stdout.flush()
+    return ['ok']
+
+
+# 
+# Check that we have the correct arguments
+#
+opts, args= getopt.getopt(sys.argv[1:], "n:")
+
+rvi_node_url = "ws://localhost:8808"
+for o, a in opts:
+    if o == "-n":
+        rvi_node_url = a
+    else:
+        usage()
+
+if len(args) != 1:
+    usage()
+
+service_name = args[0]
+
+
+ws = websocket.create_connection(rvi_node_url)
+
+tid = 1
+payload = {}
+payload['json-rpc'] = "2.0"
+payload['id'] =tid
+payload['method'] = "register_service"
+payload['params'] = {"service_name": service_name}
+
+# Register service
+ws.send(json.dumps(payload))
+reg_res = json.loads(ws.recv())
+
+full_service_name = reg_res['service']
+print "RVI node URL:        ", rvi_node_url
+print "Service:             ", full_service_name
+
+while True:
+    print 
+    print 'Press Ctrl-\ to quit.'
+    inp = json.loads(ws.recv())
+    print inp
+    params=inp['params']
+    if inp['method'] == 'services_available':
+        print "Services available:", params['services']
+
+    if inp['method'] == 'services_unavailable':
+        print "Service unavailable:", params['services']
+
+    if inp['method'] == 'message':
+        print "Service invoked."
+        print "service:    ", params['service_name']
+        print "parameters: ", params['parameters']

--- a/python/rvilib.py
+++ b/python/rvilib.py
@@ -176,16 +176,11 @@ class RVI(SimpleJSONRPCServer):
             # a regular dictionary: {'vin': 1234, hello: 'world'}
 
             # print "Parameters:", params['parameters']
-            msg_params = params['parameters'] 
-            for i in range(0, len(msg_params)):
-                for j in range(0, len(msg_params[i].keys())):
-                    # print "params", msg_params[i].keys()[j], "=", msg_params[i].values()[j]
-                    dict_param[msg_params[i].keys()[j]] = msg_params[i].values()[j]
 
             # print "Parameter disctionary: ", dict_param
             # print 
             # Ship the processed dispatch info upward.
-            return SimpleJSONRPCServer._dispatch(self, params['service_name'], dict_param)           
+            return SimpleJSONRPCServer._dispatch(self, params['service_name'], params['parameters'])
 
         # Fallthrough to all other methods.
         # Will handle service_re3


### PR DESCRIPTION
message "parameters" element is now a single, multi-member JSON object instead of an array of small single member objects.

"method" return parameter added to all service edge JSON-RPC services invoked by service.