### PR TITLE
Run RVI_CORE on OTP 18.1

### DIFF
--- a/deps/edown/README.md
+++ b/deps/edown/README.md
@@ -4,9 +4,7 @@
 
 Copyright (c) 2014 Ulf Wiger
 
-
 __Authors:__ [`ulf@wiger.net`](mailto:ulf@wiger.net).
-
 
 Status:
 ------
@@ -51,11 +49,11 @@ It is also possible to add the branch information specifically:
 `{top_level_readme, {File, BaseHref, Branch}}`, although this shouldn't be
 necessary as long as edown can derive the branch name from git.
 
-Using Atlassian Stash as target
--------------------------------
+Using Atlassian Stash or Gitlab as target
+-----------------------------------------
 
-The option `{edown_target, github | stash}` can be used to control which
-is the intended host repository. This affects how links are rewritten in
+The option `{edown_target, github | stash | gitlab}` can be used to control
+which is the intended host repository. This affects how links are rewritten in
 order to find related files and stay on the correct branch.
 
 The default value is `github`.
@@ -63,6 +61,7 @@ The default value is `github`.
 Note that at the moment, the
 [Markdown viewer plugin](https://bitbucket.org/atlassianlabs/stash-markdown-viewer-plugin) will be needed in order to render the generated documentation
 as Markdown on Stash.
+
 Github customizations
 =====================
 `pre` tags are converted into github "fenced" code blocks, i.e.
@@ -166,15 +165,4 @@ See [bin/MARKEDOC-README.md](http://github.com/uwiger/edown/blob/master/bin/MARK
 **FreeBSD, Mac OS X**`$ sed -E -f markedoc.sed <markdown file> > <edoc file>`
 
 **Linux**`$ sed -r -f markedoc.sed <markdown file> > <edoc file>`
-
-
-## Modules ##
-
-
-<table width="100%" border="0" summary="list of modules">
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_doclet.md" class="module">edown_doclet</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_layout.md" class="module">edown_layout</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_lib.md" class="module">edown_lib</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_make.md" class="module">edown_make</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/edown/blob/master/doc/edown_xmerl.md" class="module">edown_xmerl</a></td></tr></table>
 

--- a/deps/edown/doc/README.md
+++ b/deps/edown/doc/README.md
@@ -4,9 +4,7 @@
 
 Copyright (c) 2014 Ulf Wiger
 
-
 __Authors:__ [`ulf@wiger.net`](mailto:ulf@wiger.net).
-
 
 Status:
 ------
@@ -51,11 +49,11 @@ It is also possible to add the branch information specifically:
 `{top_level_readme, {File, BaseHref, Branch}}`, although this shouldn't be
 necessary as long as edown can derive the branch name from git.
 
-Using Atlassian Stash as target
--------------------------------
+Using Atlassian Stash or Gitlab as target
+-----------------------------------------
 
-The option `{edown_target, github | stash}` can be used to control which
-is the intended host repository. This affects how links are rewritten in
+The option `{edown_target, github | stash | gitlab}` can be used to control
+which is the intended host repository. This affects how links are rewritten in
 order to find related files and stay on the correct branch.
 
 The default value is `github`.
@@ -63,6 +61,7 @@ The default value is `github`.
 Note that at the moment, the
 [Markdown viewer plugin](https://bitbucket.org/atlassianlabs/stash-markdown-viewer-plugin) will be needed in order to render the generated documentation
 as Markdown on Stash.
+
 Github customizations
 =====================
 `pre` tags are converted into github "fenced" code blocks, i.e.
@@ -166,15 +165,4 @@ See [bin/MARKEDOC-README.md](bin/MARKEDOC-README.md).
 **FreeBSD, Mac OS X**`$ sed -E -f markedoc.sed <markdown file> > <edoc file>`
 
 **Linux**`$ sed -r -f markedoc.sed <markdown file> > <edoc file>`
-
-
-## Modules ##
-
-
-<table width="100%" border="0" summary="list of modules">
-<tr><td><a href="edown_doclet.md" class="module">edown_doclet</a></td></tr>
-<tr><td><a href="edown_layout.md" class="module">edown_layout</a></td></tr>
-<tr><td><a href="edown_lib.md" class="module">edown_lib</a></td></tr>
-<tr><td><a href="edown_make.md" class="module">edown_make</a></td></tr>
-<tr><td><a href="edown_xmerl.md" class="module">edown_xmerl</a></td></tr></table>
 

--- a/deps/edown/doc/edoc-info
+++ b/deps/edown/doc/edoc-info
@@ -1,4 +1,3 @@
 %% encoding: UTF-8
 {application,edown}.
-{packages,[]}.
 {modules,[edown_doclet,edown_layout,edown_lib,edown_make,edown_xmerl]}.

--- a/deps/edown/doc/edown_doclet.md
+++ b/deps/edown/doc/edown_doclet.md
@@ -5,11 +5,12 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 EDoc Doclet module for producing Markdown.
-Copyright (c) 2014 Ulf Wiger
+
+Copyright (c) 2014-2015 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="index"></a>
 
 ## Function Index ##
@@ -26,21 +27,16 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 ### run/2 ###
 
-
 <pre><code>
 run(Command::<a href="#type-doclet_gen">doclet_gen()</a> | <a href="#type-doclet_toc">doclet_toc()</a>, Ctxt::<a href="#type-edoc_context">edoc_context()</a>) -&gt; ok
 </code></pre>
 <br />
 
-
 Main doclet entry point.
-
-
 
 Also see [`//edoc/edoc:layout/2`](http://www.erlang.org/doc/man/edoc.html#layout-2) for layout-related options, and
 [`//edoc/edoc:get_doc/2`](http://www.erlang.org/doc/man/edoc.html#get_doc-2) for options related to reading source
 files.
-
 
 Options:
 

--- a/deps/edown/doc/edown_layout.md
+++ b/deps/edown/doc/edown_layout.md
@@ -5,15 +5,16 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 Markdown layout module for EDoc.
+
 Copyright (c) 2014 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="description"></a>
 
 ## Description ##
-  Derived from `edoc_layout`, which is part of the Erlang/OTP application EDoc.
+Derived from `edoc_layout`, which is part of the Erlang/OTP application EDoc.
 The module is intended to be used together with edoc.<a name="index"></a>
 
 ## Function Index ##
@@ -32,16 +33,13 @@ The module is intended to be used together with edoc.<a name="index"></a>
 
 `markdown(Title, CSS, Body) -> any()`
 
-
 <a name="module-2"></a>
 
 ### module/2 ###
 
 `module(Element, Options) -> any()`
 
-
 The layout function.
-
 
 Options to the standard layout:
 
@@ -116,14 +114,13 @@ used for exporting the documentation. See <a href="http://www.erlang.org/doc/man
 
 
 
-
 __See also:__ [//edoc/edoc:layout/2](http://www.erlang.org/doc/man/edoc.html#layout-2), [edown_doclet:layout/2](edown_doclet.md#layout-2).
+
 <a name="overview-2"></a>
 
 ### overview/2 ###
 
 `overview(E, Options) -> any()`
-
 
 <a name="package-2"></a>
 
@@ -131,11 +128,9 @@ __See also:__ [//edoc/edoc:layout/2](http://www.erlang.org/doc/man/edoc.html#lay
 
 `package(E, Options) -> any()`
 
-
 <a name="type-1"></a>
 
 ### type/1 ###
 
 `type(E) -> any()`
-
 

--- a/deps/edown/doc/edown_lib.md
+++ b/deps/edown/doc/edown_lib.md
@@ -5,29 +5,29 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 Markdown for EDoc - common support functions.
+
 Copyright (c) 2014 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="index"></a>
 
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#export-1">export/1</a></td><td></td></tr><tr><td valign="top"><a href="#get_attrval-2">get_attrval/2</a></td><td></td></tr><tr><td valign="top"><a href="#redirect_uri-1">redirect_uri/1</a></td><td></td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#export-2">export/2</a></td><td></td></tr><tr><td valign="top"><a href="#get_attrval-2">get_attrval/2</a></td><td></td></tr><tr><td valign="top"><a href="#redirect_uri-1">redirect_uri/1</a></td><td></td></tr></table>
 
 
 <a name="functions"></a>
 
 ## Function Details ##
 
-<a name="export-1"></a>
+<a name="export-2"></a>
 
-### export/1 ###
+### export/2 ###
 
-`export(Data) -> any()`
-
+`export(Data, Options) -> any()`
 
 <a name="get_attrval-2"></a>
 
@@ -35,11 +35,9 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 `get_attrval(Name, XmlElement) -> any()`
 
-
 <a name="redirect_uri-1"></a>
 
 ### redirect_uri/1 ###
 
 `redirect_uri(XmlElement) -> any()`
-
 

--- a/deps/edown/doc/edown_make.md
+++ b/deps/edown/doc/edown_make.md
@@ -4,7 +4,6 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 <a name="index"></a>
 
 ## Function Index ##
@@ -21,61 +20,44 @@
 
 ### from_script/1 ###
 
-
 <pre><code>
 from_script(Config::ConfigFile) -&gt; ok | {error, Reason}
 </code></pre>
 <br />
 
-
 Reads ConfigFile and calls [`edoc:application/3`](edoc.md#application-3)
-
-
 
 The ConfigFile will be read using [`file:script/1`](file.md#script-1), and should return
 `{App, Dir, Options}`, as required by [`edoc:application/3`](edoc.md#application-3).
 
-
 This function does not manage dependencies. It is simply a wrapper around
 [`edoc:application/3`](edoc.md#application-3).
+
 <a name="main-1"></a>
 
 ### main/1 ###
-
 
 <pre><code>
 main(Args::[Config]) -&gt; no_return()
 </code></pre>
 <br />
 
-
 Escript entry point for building edown (or edoc) documentation
-
-
 
 Usage: edown_make -config ConfigFile [-pa P] [-pz P]
 
-
-
 Calls [from_script(ConfigFile)](#from_script-1) and then terminates,
 with a normal or non-normal exit code, depending on the outcome.
-
-
 
 Make sure `$EDOWN/edown_make` is runnable, and in the command path, and
 that the edown BEAM files are in the Erlang path (e.g. using $ERL_LIBS).
 The `edown_make` escript also accepts `-pa P` and/or `-pz P` flags as a
 means of locating the edown byte code.
 
-
-
 Note, however, that the function `edoc_make:main/1` only expects the
 config file as an input argument, corresponding to
 
-
-
 `escript edoc_make.beam ConfigFile`
-
 
 (The reason for this is that if the beam file can be passed directly to
 the escript command, setting the path should also be doable that way).

--- a/deps/edown/doc/edown_xmerl.md
+++ b/deps/edown/doc/edown_xmerl.md
@@ -7,6 +7,7 @@
 Copyright (c) 2014 Ulf Wiger
 
 __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
+
 <a name="index"></a>
 
 ## Function Index ##
@@ -25,13 +26,11 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 `#element#(Tag, Data, Attrs, Parents, E) -> any()`
 
-
 <a name="%23root%23-4"></a>
 
 ### '#root#'/4 ###
 
 `#root#(Data, Attrs, X3, E) -> any()`
-
 
 <a name="%23text%23-1"></a>
 
@@ -39,11 +38,9 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 `#text#(Text) -> any()`
 
-
 <a name="%23xml-inheritance%23-0"></a>
 
 ### '#xml-inheritance#'/0 ###
 
 `#xml-inheritance#() -> any()`
-
 

--- a/deps/edown/doc/overview.edoc
+++ b/deps/edown/doc/overview.edoc
@@ -45,11 +45,11 @@ It is also possible to add the branch information specifically:
 `{top_level_readme, {File, BaseHref, Branch}}', although this shouldn't be
 necessary as long as edown can derive the branch name from git.
 
-Using Atlassian Stash as target
--------------------------------
+Using Atlassian Stash or Gitlab as target
+-----------------------------------------
 
-The option `{edown_target, github | stash}' can be used to control which
-is the intended host repository. This affects how links are rewritten in
+The option `{edown_target, github | stash | gitlab}' can be used to control
+which is the intended host repository. This affects how links are rewritten in
 order to find related files and stay on the correct branch.
 
 The default value is `github'.

--- a/deps/edown/src/edown_lib.erl
+++ b/deps/edown/src/edown_lib.erl
@@ -23,14 +23,18 @@
 
 -module(edown_lib).
 
--export([export/1, redirect_uri/1, get_attrval/2]).
+-export([export/2, redirect_uri/1, get_attrval/2]).
 
 -include_lib("xmerl/include/xmerl.hrl").
 
+-define(HTML_EXPORT, edown_xmerl).
+-define(DEFAULT_XML_EXPORT, ?HTML_EXPORT).
 
-export(Data) ->
-    xmerl:export_simple_content(Data, edown_xmerl).
+export(Data, Options) ->
+    xmerl:export_simple(Data, export_module(Options)).
 
+export_module(Options) ->
+    proplists:get_value(xml_export, Options, ?DEFAULT_XML_EXPORT).
 
 redirect_uri(#xmlElement{} = E) ->
     redirect_uri(get_attrval(href, E), get_attrval(name, E), E);


### PR DESCRIPTION
Initial tests suggest that all it takes to switch to OTP 18.1 and make the test suite pass is:
* upgrade edown to the latest version (we don't use edown, but it needs to at least compile to honor dependencies)
* Recompile. Some new warnings will appear, mostly in regard to use of `erlang:now/0`, but AFAICT nothing serious.

I ran my test on OTP 18.1.2. The latest tag is 18.1.5, but the differences seem limited to bug fixes in `inets` and `ssh`, neither of which are essential to RVI.

A major reason to switch to OTP 18 now is that the `ssl` application in R16B03 lacks some options for validating incomplete certificate paths. I believe we need this for our switch to X.509 certificates and the new authentication protocol. Basically, the 'server' needs to fetch the peer cert, which it only does if it tells you that it must validate it (`fail_if_no_peer_cert`), but in order for the validation to succeed, we must be able to assist in finding the root cert (`partial_chain`). It's the `partial_chain`, among others, that's missing in R16.