### PR TITLE
Uw test3 fixes

### DIFF
--- a/components/authorize/src/authorize_keys.erl
+++ b/components/authorize/src/authorize_keys.erl
@@ -19,6 +19,7 @@
 	 json_to_public_key/1]).
 
 -export([self_signed_public_key/0]).  % just temporary
+-export([strip_nl/1]).
 -export([pp_key/1,
 	 abbrev/1,
 	 abbrev_bin/1,
@@ -669,7 +670,10 @@ abbrev_payload(PL) ->
 
 abbrev_jwt({Hdr, Body} = X) ->
     try {Hdr, abbrev_payload(Body)}
-    catch error:_ -> X end.
+    catch error:_ -> X end;
+abbrev_jwt(X) ->
+    X.
+
 
 abbrev_pl(#cred{} = Payload) ->
     list_to_tuple(lists:map(fun(B) when is_binary(B) -> abbrev_bin(B);

--- a/components/authorize/src/authorize_rpc.erl
+++ b/components/authorize/src/authorize_rpc.erl
@@ -238,7 +238,7 @@ handle_call({rvi, validate_message, [JWT, Conn | LogId]}, _, State) ->
 	    log(LogId, error, "validation FAILED", []),
 	    {reply, [not_found], State}
     end;
-handle_call({rvi, get_credentials, [_LogId]}, _From, State) ->
+handle_call({rvi, get_credentials, _Args}, _From, State) ->
     {reply, [ ok, authorize_keys:get_credentials() ], State};
 
 handle_call({rvi, validate_authorization, [JWT, Conn | [_] = LogId]}, _From, State) ->
@@ -369,7 +369,7 @@ get_json_element(Path, JSON, Default) ->
     end.
 
 store_cred(CredJWT, Conn, PeerCert, LogId) ->
-    case authorize_sig:decode_jwt(CredJWT, authorize_keys:provisioning_key()) of
+    case authorize_sig:decode_jwt(authorize_keys:strip_nl(CredJWT), authorize_keys:provisioning_key()) of
 	{_CHeader, CredStruct} ->
 	    case authorize_keys:save_cred(CredStruct, CredJWT, Conn, PeerCert, LogId) of
 		ok ->

--- a/components/dlink_bt/src/dlink_bt_rpc.erl
+++ b/components/dlink_bt/src/dlink_bt_rpc.erl
@@ -303,7 +303,7 @@ announce_local_service_(CompSpec, Service, Availability) ->
 process_data(_FromPid, RemoteBTAddr, RemoteChannel, ProtocolMod, Data, CompSpec) ->
     ?debug("dlink_bt:receive_data(): SetupAddress: {~p, ~p}", [ RemoteBTAddr, RemoteChannel ]),
     ?debug("dlink_bt:receive_data(): ~p:receive_message(~p)", [ ProtocolMod, Data ]),
-    Proto = list_to_existing_atom(ProtocolMod),
+    Proto = binary_to_existing_atom(ProtocolMod, latin1),
     Proto:receive_message(CompSpec, {RemoteBTAddr, RemoteChannel}, Data),
 
     ok.
@@ -593,7 +593,7 @@ handle_call({rvi, send_data, [ProtoMod, Service, Data, _DataLinkOpts]}, _From, S
 		    ConnPid,
 		    [ { ?DLINK_ARG_TRANSACTION_ID, 1 },
 		      { ?DLINK_ARG_CMD, ?DLINK_CMD_RECEIVE },
-		      { ?DLINK_ARG_MODULE, atom_to_list(ProtoMod) },
+		      { ?DLINK_ARG_MODULE, atom_to_binary(ProtoMod, latin1) },
 		      { ?DLINK_ARG_DATA,  Data }
 		    ]),
 	    { reply, [ Res ], St}

--- a/components/dlink_tcp/src/dlink_tcp_rpc.erl
+++ b/components/dlink_tcp/src/dlink_tcp_rpc.erl
@@ -550,7 +550,7 @@ handle_call({rvi, send_data, [ProtoMod, Service, Data, _DataLinkOpts]}, _From, S
  	    Res = connection:send(ConnPid,
 				  [ { ?DLINK_ARG_TRANSACTION_ID, 1 },
 				    { ?DLINK_ARG_CMD, ?DLINK_CMD_RECEIVE },
-				    { ?DLINK_ARG_MODULE, atom_to_list(ProtoMod) },
+				    { ?DLINK_ARG_MODULE, atom_to_binary(ProtoMod, latin1) },
 				    { ?DLINK_ARG_DATA, Data }
 				  ]),
 	    { reply, [ Res ], St}
@@ -727,7 +727,7 @@ connection_authorized(FromPid, {RemoteIP, RemotePort} = Conn, CompSpec) ->
 process_data(_FromPid, RemoteIP, RemotePort, ProtocolMod, Data, CompSpec) ->
     ?debug("dlink_tcp:receive_data(): RemoteAddr: {~p, ~p}", [ RemoteIP, RemotePort ]),
     ?debug("dlink_tcp:receive_data(): ~p:receive_message(~p)", [ ProtocolMod, Data ]),
-    Proto = list_to_existing_atom(ProtocolMod),
+    Proto = binary_to_existing_atom(ProtocolMod, latin1),
     Proto:receive_message(CompSpec, {RemoteIP, RemotePort}, Data).
 
 process_announce(Avail, Services, FromPid, IP, Port, CompSpec) ->

--- a/components/dlink_tls/src/dlink_tls_rpc.erl
+++ b/components/dlink_tls/src/dlink_tls_rpc.erl
@@ -44,7 +44,7 @@
 -define(DEFAULT_TCP_ADDRESS, "0.0.0.0").
 -define(DEFAULT_PING_INTERVAL, 300000).  %% Five minutes
 -define(SERVER, ?MODULE).
--define(DLINK_TLS_VERSION, "1.0").
+-define(DLINK_TLS_VERSION, <<"1.0">>).
 
 -define(CONNECTION_TABLE, rvi_dlink_tls_connections).
 -define(SERVICE_TABLE, rvi_dlink_tls_services).
@@ -565,7 +565,7 @@ handle_info({ rvi_ping, Pid, Address, Port, Timeout},  St) ->
     case dlink_tls_conn:is_connection_up(Pid) of
 	true ->
 	    ?info("dlink_tls:ping(): Pinging: ~p:~p", [Address, Port]),
- 	    dlink_tls_conn:send(Pid, term_to_json({ struct, [{ ?DLINK_ARG_CMD, ?DLINK_CMD_PING }]})),
+ 	    dlink_tls_conn:send(Pid, [{ ?DLINK_ARG_CMD, ?DLINK_CMD_PING }]),
 	    erlang:send_after(Timeout, self(),
 			      { rvi_ping, Pid, Address, Port, Timeout });
 
@@ -689,7 +689,7 @@ send_authorize(Pid, CompSpec) ->
 			       [{?DLINK_ARG_CMD, ?DLINK_CMD_AUTHORIZE},
 				{?DLINK_ARG_VERSION, ?DLINK_TLS_VERSION},
 				{?DLINK_ARG_ADDRESS, LocalIP},
-				{?DLINK_ARG_PORT, integer_to_list(LocalPort)},
+				{?DLINK_ARG_PORT, LocalPort},
 				{?DLINK_ARG_CREDENTIALS, Creds}], CompSpec)).
     %% dlink_tls_conn:send(Pid,
     %% 			term_to_json(

--- a/components/rvi_common/src/rvi_common.erl
+++ b/components/rvi_common/src/rvi_common.erl
@@ -124,7 +124,7 @@ json_argument([], [], Acc) ->
     lists:reverse(Acc);
 
 json_argument([Arg | AT], [Spec | ST], Acc) when is_atom(Arg)->
-    json_argument(AT, ST, [ { Spec, atom_to_list(Arg) } | Acc]);
+    json_argument(AT, ST, [ { Spec, atom_to_binary(Arg, latin1) } | Acc]);
 
 json_argument([Arg | AT], [Spec | ST], Acc) ->
     json_argument(AT, ST, [ { Spec, Arg } | Acc]).
@@ -162,7 +162,7 @@ request(Component,
 	    ?debug("Sending ~p:~p(~p) -> ~p.", [Module, Function, InArg, JSONArg]),
 
 	    case get_request_result(
-		   send_json_request(URL, atom_to_list(Function),  JSONArg)
+		   send_json_request(URL, atom_to_binary(Function, latin1),  JSONArg)
 		  ) of
 
 		{ ok, JSONBody} ->
@@ -330,7 +330,7 @@ get_json_element_([], JSON) ->
 %% All proplist keys in JSON are strings.
 %% Convert atomically provided path elements to strings
 get_json_element_([Elem | T], JSON ) when is_atom(Elem) ->
-    get_json_element_([atom_to_list(Elem) | T], JSON);
+    get_json_element_([atom_to_binary(Elem, latin1) | T], JSON);
 
 get_json_element_(Path, {Type, JSON}) when Type==array;
 					   Type==struct ->

--- a/components/service_edge/src/service_edge_rpc.erl
+++ b/components/service_edge/src/service_edge_rpc.erl
@@ -225,7 +225,7 @@ handle_websocket(WSock, Mesg, Arg) ->
 	{ok, Reply} ->
 	    EncReply = rvi_common:term_to_json([{id, ID} |Reply]),
 	    ?debug("service_edge_rpc:handle_websocket(~p/~p) reply:      ~s", [ WSock, ID, EncReply]),
-	    wse_server:send(WSock, list_to_binary(EncReply))
+	    wse_server:send(WSock, iolist_to_binary(EncReply))
     end,
     ok.
 


### PR DESCRIPTION
Fixes for bugs found while testing interop with Lilli's code. Mainly:
* Wrong encoding of JSON messages
* authorize_rpc code assumed that rvi_doc_id would always be included in a request
* intolerant pretty-printing of (invalid) JWT
* JWT validation code sensitive to trailing newlines (stripped only when reading from file)