### PR TITLE
rewrite json decoder transition code in rvi_common

### DIFF
--- a/components/dlink_tcp/src/connection.erl
+++ b/components/dlink_tcp/src/connection.erl
@@ -46,7 +46,6 @@
 	  sock = undefined,
 	  mod = undefined,
 	  func = undefined,
-	  args = undefined,
 	  packet_mod = ?PACKET_MOD,
 	  packet_st = [],
 	  decode_st = <<>>,
@@ -289,9 +288,9 @@ handle_info({tcp_closed, Sock},
 		  port = Port,
 		  mod = Mod,
 		  func = Fun,
-		  args = Arg } = State) ->
+		  cs = CS } = State) ->
     ?debug("handle_info(tcp_closed): Address: ~p:~p ", [IP, Port]),
-    Mod:Fun(self(), IP, Port, closed, Arg),
+    Mod:Fun(self(), IP, Port, closed, CS),
     gen_tcp:close(Sock),
     connection_manager:delete_connection_by_pid(self()),
     {stop, normal, State};
@@ -302,10 +301,10 @@ handle_info({tcp_error, _Sock},
 		  port = Port,
 		  mod = Mod,
 		  func = Fun,
-		  args = Arg} = State) ->
+		  cs = CS} = State) ->
 
     ?debug("handle_info(tcp_error): Address: ~p:~p ", [IP, Port]),
-    Mod:Fun(self(), IP, Port, error, Arg),
+    Mod:Fun(self(), IP, Port, error, CS),
     connection_manager:delete_connection_by_pid(self()),
     {stop, normal, State};
 

--- a/components/dlink_tcp/src/dlink_tcp_rpc.erl
+++ b/components/dlink_tcp/src/dlink_tcp_rpc.erl
@@ -375,7 +375,6 @@ handle_socket_(FromPid, PeerIP, PeerPort, data, Elems, CompSpec) ->
                          ProtoMod, Data, CompSpec);
 
         ?DLINK_CMD_PING ->
-            ?info("dlink_tcp:ping(): Pinged from: ~p:~p", [ PeerIP, PeerPort ]),
             ok;
 
         undefined ->
@@ -574,7 +573,6 @@ handle_info({ rvi_ping, Pid, Address, Port, Timeout},  St) ->
     %% Check that connection is up
     case connection:is_connection_up(Pid) of
 	true ->
-	    ?info("dlink_tcp:ping(): Pinging: ~p:~p", [Address, Port]),
  	    connection:send(Pid, [{?DLINK_ARG_CMD, ?DLINK_CMD_PING}]),
 	    erlang:send_after(Timeout, self(),
 			      { rvi_ping, Pid, Address, Port, Timeout });


### PR DESCRIPTION
Some transition code in rvi_common used to ease the switch to the jsx JSON decoder was causing some issues handling websocket requests.