### PR TITLE
Uw tls noverify

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,19 +1,19 @@
-Copyright (C) 2014-2015, Jaguar Land Rover
+Copyright (C) 2014-2016, Jaguar Land Rover
 
 This document is licensed under Creative Commons
 Attribution-ShareAlike 4.0 International.
 
-**Version 0.4.0**
+**Version 0.5.0**
 
 # BUILD INSTRUCTIONS FOR RVI #
 
 This document describes the build process for the RVI project on an
-Ubuntu 14.01 Linux machine.
+Ubuntu 14.04 Linux machine.
 
 Please see ```README.md``` for a general description of the project
 and its structure.
 
-Please see ```CONFIGURE.md``` for details on cofniguring and launching
+Please see ```CONFIGURE.md``` for details on configuring and launching
 the system once it has been built.
 
 The first milestone of the RVI project is the HVAC demo. Please see
@@ -31,7 +31,7 @@ Please note that the configuraiton process, described in
 
 # PREREQUISITES #
 
-1. The Ubuntu 14.01 system have the latest updates installed.
+1. The Ubuntu 14.04 system have the latest updates installed.
 2. The user can gain root access to install packages.
 3. There is at least 5GB of space availabled for packages and code.
 
@@ -46,8 +46,17 @@ Grade Linux repositories where the code resides:
 
 ## INSTALL ERLANG ##
 
-Install Erlang R16B03, or a later R16 release:
+Install Erlang 18.2, or a later version 18 release:
 
+Tested packages of the latest versions of Erlang can be downloaded from [packages.erlang-solutions.com](https://www.erlang-solutions.com/resources/download.html)
+
+Add the following line to your /etc/apt/sources.list
+
+    deb http://packages.erlang-solutions.com/ubuntu trusty contrib
+
+Update and install erlang
+
+    sudo apt-get update
     sudo apt-get install erlang
 
 
@@ -60,26 +69,6 @@ to the build system.
 
 The clone will be downloaded into a newly created ```rvi_core``` subdirectory.
 
-
-## RETRIEVE ADDITIONAL CODE DEPENDENCIES ##
-
-Move into the newly created ```rvi_core``` directory where the code resides.
-
-    cd rvi_core
-
-Run ```make deps``` to pull all necessary repositories into the ```deps```
-subdirectory under the ```rvi``` directory:
-
-    make deps
-	
-The local ```rebar``` command is used to retrieve the dependencies. See
-```rebar.config``` and ```deps/*/rebar.config``` for a list of
-dependencies. 
-
-See the [rebar](https://github.com/basho/rebar) project for a detailed
-description of the rebar Erlang build tool.
-
-
 ## BUILD THE RVI SYSTEM ##
 
 Run ```make``` to build the dependency code in ```deps``` and the
@@ -87,17 +76,41 @@ top level project in the ```rvi``` directory.
 
     make compile
 
-The following warnings are expected, and are not a failure indication:
+The local ```rebar``` command is used to retrieve the dependencies. See
+```rebar.config``` and ```deps/*/rebar.config``` for a list of
+dependencies. 
 
-    .../exo_ssh.erl:18: Warning: undefined callback function code_change/3 (behaviour 'ssh_channel')
-	...
-	.../bert_challenge.erl:223: Warning: crypto:sha/1 is deprecated and will be removed in in a future release; use crypto:hash/2
-	...
-	.../bert_challenge.erl:230: Warning: crypto:sha/1 is deprecated and will be removed in in a future release; use crypto:hash/2
+See the [rebar](https://github.com/basho/rebar) project for a detailed
+description of the rebar Erlang build tool.
+
+    Expected output:
+    $ make
+    ./rebar get-deps
+    ==> goldrush (get-deps)
+    ==> lager (get-deps)
+    ==> src (get-deps)
+    ==> ale (get-deps)
+    ==> src (get-deps)
     ...
-    .../authorize_rpc.erl:31: Warning: function get_certificate_body/2 is unused    
+    ./rebar  compile
+    ==> goldrush (compile)
+    Compiled src/glc.erl
+    Compiled src/glc_lib.erl
+    Compiled src/glc_code.erl
+    ...
+    /.../rvi_core/deps/exo/src/exo_ssh.erl:18: Warning: undefined callback function code_change/3 (behaviour 'ssh_channel')
+    /.../rvi_core/deps/exo/src/exo_ssh.erl:18: Warning: undefined callback function handle_call/3 (behaviour 'ssh_channel')
+    ...
+    cp deps/setup/setup_gen scripts/
+    (cd components/authorize && make escript)
+    ERL_LIBS=/.../rvi_core/components/authorize/..:/..../jlr/rvi_core/components/authorize/../../deps ./rebar escriptize
+    ==> authorize (escriptize)
+    cp components/authorize/author scripts/
+    $
 
-The compiled code is available under ```ebin/``` and ```deps/*/ebin```.
+Some warnings are expected, and are usually not a failure indication:
+
+The compiled code is available under ```ebin/```, ```components/*/ebin``` and ```deps/*/ebin```.
 
 ## CREATE A RELEASE ##
 

--- a/components/dlink_tls/src/dlink_tls_conn.erl
+++ b/components/dlink_tls/src/dlink_tls_conn.erl
@@ -421,12 +421,13 @@ do_upgrade(Sock, client, CompSpec) ->
     ?debug("TLS Opts = ~p", [Opts]),
     {DoVerify, ssl:connect(Sock, Opts)};
 do_upgrade(Sock, server, CompSpec) ->
-    {DoVerify, Opts} = tls_opts(client, CompSpec),
+    {DoVerify, Opts} = tls_opts(server, CompSpec),
     ?debug("TLS Opts = ~p", [Opts]),
     {DoVerify, ssl:ssl_accept(Sock, Opts)}.
 
 tls_opts(Role, CompSpec) ->
-    TlsOpts = rvi_common:get_value(tls_opts, [], CompSpec),
+    {ok, ServerOpts} = get_module_config(server_opts, [], CompSpec),
+    TlsOpts = rvi_common:get_value(tls_opts, ServerOpts, CompSpec),
     Opt = fun(K) -> opt(K, TlsOpts,
                         fun() ->
                                 ok(setup:get_env(rvi_core, K))

--- a/components/dlink_tls/src/dlink_tls_rpc.erl
+++ b/components/dlink_tls/src/dlink_tls_rpc.erl
@@ -222,7 +222,7 @@ connect_remote(IP, Port, CompSpec) ->
 	not_found ->
 	    %% Setup a new outbound connection
 	    {ok, Timeout} = rvi_common:get_module_config(
-			      dlink_tls, ?MODULE, connect_timeout, 10000, CompSpec),
+			      data_link, ?MODULE, connect_timeout, 10000, CompSpec),
 	    ?info("dlink_tls:connect_remote(): Connecting ~p:~p (TO=~p",
 		  [IP, Port, Timeout]),
 	    log("new connection", [], CompSpec),

--- a/doc/rvi_protocol.md
+++ b/doc/rvi_protocol.md
@@ -15,7 +15,7 @@ This document describes the core protocol between two RVI nodes.
 [6] X.509 Certificates - (link)[https://en.wikipedia.org/wiki/X.509]<br>
 
 # FEATURES COVERED BY PROTOCOL
-1. **Authroization**<br>
+1. **Authorization**<br>
 Prove to the remote RVI node that the local RVI node has the right to
 invoke a set of services, and the right to register another set of services.
 
@@ -257,7 +257,7 @@ openssl genrsa -out insecure_root_key.pem 1024
 openssl req -x509 -new -nodes -key insecure_root_key.pem -days 365 -out insecure_root_cert.crt
 ```
 
-The content of the sample ```insercure_root_key.pem``` private key
+The content of the sample ```insecure_root_key.pem``` private key
 file, which has no password protection, is:
 
 ```
@@ -328,7 +328,7 @@ openssl x509 -req -days 365 -in insecure_device_cert.csr \
 The ```insecure_device_cert.csr``` intermediate certificate signing
 request can be deleted once the three steps above have been executed.
 
-The content of the sample ```insercure_device_key.pem``` private key
+The content of the sample ```insecure_device_key.pem``` private key
 file, which has no password protection, is:
 
 ```

--- a/priv/test_config/tls_backend_noverify.config
+++ b/priv/test_config/tls_backend_noverify.config
@@ -1,0 +1,16 @@
+%% -*- erlang -*-
+[
+ {include_lib, "rvi_core/priv/test_config/backend.config"},
+ {set_env,
+  [
+   {rvi_core,
+    [
+     { [routing_rules, ""], [{proto_msgpack_rpc, dlink_tls_rpc}] },
+     { [components, data_link], [{dlink_tls_rpc, gen_server,
+				  [{server_opts, [{port, 8807},
+						  {verify, false},
+						  {ping_interval,500}]}]}]},
+     { [components, protocol], [{proto_msgpack_rpc, gen_server, []}] }
+    ]}
+  ]}
+].

--- a/priv/test_config/tls_sample_noverify.config
+++ b/priv/test_config/tls_sample_noverify.config
@@ -1,0 +1,18 @@
+%% -*- erlang -*-
+[
+ {include_lib, "rvi_core/priv/test_config/sample.config"},
+ {set_env,
+  [
+   {rvi_core,
+    [
+     { [routing_rules, ""], [{proto_msgpack_rpc, dlink_tls_rpc}] },
+     { [components, data_link], [{dlink_tls_rpc, gen_server,
+				  [{server_opts, [{port, 9007},
+%						  {verify, false},
+						  {ping_interval,500}]},
+				   {persistent_connections,
+				    ["localhost:8807"]}]}]},
+     { [components, protocol], [{ proto_msgpack_rpc, gen_server, [] }] }
+    ]}
+  ]}
+].

--- a/scripts/rvi
+++ b/scripts/rvi
@@ -12,7 +12,7 @@
 # If a UUID file has not been created, it will be done at this time.
 #
 
-SELF_DIR=$(dirname $(readlink -f "$0"))
+SELF_DIR=$(cd ${0%/*} && pwd)
 CONFIG_DIR=/etc/opt/rvi
 BIN_DIR=/opt/rvi
 

--- a/scripts/rvi.sh
+++ b/scripts/rvi.sh
@@ -12,7 +12,7 @@
 # through an RPM.
 #
 
-SELF_DIR=$(dirname $(readlink -f "$0"))
+SELF_DIR=$(cd ${0%/*} && pwd)
 
 ERL=${ERL:=erl}
 
@@ -104,7 +104,7 @@ fi
 # Check that we have a config dir
 if [ ! -d ${CONFIG_DIR} ]
 then
-    install -d --mode=0755 ${CONFIG_DIR}
+    install -d -m 0755 ${CONFIG_DIR}
 fi
 
 # Check if we have a uuid file.
@@ -166,8 +166,8 @@ LAUNCH="${ERL} +A 128 -boot ${CONFIG_DIR}/rvi/start -sname ${SNAME} -config ${CO
 
 case "${CMD}" in
    start)
-	 install -d --mode 0755  ${TMP_DIR}
-	 install -d --mode 0755  ${LOG_DIR}
+	 install -d -m 0755  ${TMP_DIR}
+	 install -d -m 0755  ${LOG_DIR}
 	 cd ${SELF_DIR}
 	 exec run_erl -daemon ${TMP_DIR}/ ${LOG_DIR} "exec ${LAUNCH}"
 	 ;;

--- a/scripts/rvi_install.sh
+++ b/scripts/rvi_install.sh
@@ -24,7 +24,9 @@
 #  In order to create a standalone release, use create_rvi_release.sh
 #
 
-SELF_DIR=$(dirname $(readlink -f "$0"))
+#SELF_DIR=$(dirname $(readlink -f "$0"))
+SELF_DIR=$(cd ${0%/*} && pwd)
+echo "SELF_DIR=$SELF_DIR"
 SETUP_GEN=$SELF_DIR/setup_gen  # Ulf's kitchen sink setup utility
 
 usage() {
@@ -62,20 +64,20 @@ cd ${SELF_DIR}/..;
 
 rm -rf ${TARGET_DIR} > /dev/null 2>&1 
 
-install --mode=0755 -d ${TARGET_DIR}/rvi_core
-install --mode=0755 -d ${TARGET_DIR}/scripts
+install -m 0755 -d ${TARGET_DIR}/rvi_core
+install -m 0755 -d ${TARGET_DIR}/scripts
 
 FILE_SET=$(find priv ebin components deps -name ebin -o -name priv)
 
 echo "Installing rvi at ${TARGET_DIR}."
 
 tar cf - ${FILE_SET} | (cd ${TARGET_DIR}/rvi_core ; tar xf - )
-install --mode=0755 scripts/rvi.sh ${TARGET_DIR}
-install --mode=0755 scripts/setup_gen ${TARGET_DIR}/scripts
-install --mode=0755 rel/files/nodetool ${TARGET_DIR}/scripts
-install --mode=0755 scripts/rvi_create_root_key.sh ${TARGET_DIR}/scripts
-install --mode=0755 scripts/rvi_create_device_key.sh ${TARGET_DIR}/scripts
-install --mode=0755 scripts/rvi_create_certificate_key.sh ${TARGET_DIR}/scripts
+install -m 0755 scripts/rvi.sh ${TARGET_DIR}
+install -m 0755 scripts/setup_gen ${TARGET_DIR}/scripts
+install -m 0755 rel/files/nodetool ${TARGET_DIR}/scripts
+install -m 0755 scripts/rvi_create_root_key.sh ${TARGET_DIR}/scripts
+install -m 0755 scripts/rvi_create_device_key.sh ${TARGET_DIR}/scripts
+install -m 0755 scripts/rvi_create_certificate_key.sh ${TARGET_DIR}/scripts
 
 
 echo "RVI installed under ${TARGET_DIR}"

--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -702,7 +702,7 @@ install_rvi_node(Name, Env, _ConfigF) ->
     ct:log("install_rvi_node/1 -> ~p", [Res]),
 
 
-    Res1 = cmd(lists:flatten(["install -d --mode 0755 ./", Name])),
+    Res1 = cmd(lists:flatten(["install -d -m 0755 ./", Name])),
     ct:log("install_rvi_node/2 -> ~p", [Res1]),
 
     Res2 = cmd(lists:flatten(["cp -r ", Root, "/priv ", Name])),

--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -22,6 +22,8 @@
     t_install_tls_sample_node/1,
     t_install_tlsj_backend_node/1,
     t_install_tlsj_sample_node/1,
+    t_install_tls_backend_noverify_node/1,
+    t_install_tls_sample_noverify_node/1,
     t_install_bt_backend_node/1,
     t_install_bt_sample_node/1,
     t_start_basic_backend/1,
@@ -32,6 +34,8 @@
     t_start_tls_sample/1,
     t_start_tlsj_backend/1,
     t_start_tlsj_sample/1,
+    t_start_tls_backend_noverify/1,
+    t_start_tls_sample_noverify/1,
     t_register_lock_service/1,
     t_register_sota_service/1,
     t_call_lock_service/1,
@@ -55,6 +59,7 @@ all() ->
      {group, test_run},
      {group, test_run_tls},
      {group, test_run_tlsj},
+     {group, test_run_tls_noverify},
      {group, test_run_bt}
     ].
 
@@ -74,6 +79,8 @@ groups() ->
        t_install_tls_sample_node,
        t_install_tlsj_backend_node,
        t_install_tlsj_sample_node,
+       t_install_tls_backend_noverify_node,
+       t_install_tls_sample_noverify_node,
        t_install_bt_backend_node,
        t_install_bt_sample_node
       ]},
@@ -112,6 +119,19 @@ groups() ->
        t_call_sota_service,
        t_multicall_sota_service,
        t_remote_call_lock_service,
+       t_no_errors
+      ]},
+     {test_run_tls_noverify, [],
+      [
+       t_start_tls_backend_noverify,
+       t_start_tls_sample_noverify,
+       t_register_lock_service,
+       t_register_sota_service,
+       t_call_lock_service,
+       t_remote_call_lock_service,
+       t_call_sota_service,
+       t_multicall_sota_service,
+       t_check_rvi_log,
        t_no_errors
       ]},
      {test_run_bt, [],
@@ -227,6 +247,13 @@ t_install_tlsj_backend_node(_Config) ->
 t_install_tlsj_sample_node(_Config) ->
     install_sample_node("tlsj_sample", "tlsj_sample.config").
 
+t_install_tls_backend_noverify_node(_Config) ->
+    install_rvi_node("tls_backend_noverify", env(),
+		     [root(), "/priv/test_config/tls_backend_noverify.config"]).
+
+t_install_tls_sample_noverify_node(_Config) ->
+    install_sample_node("tls_sample_noverify", "tls_sample_noverify.config").
+
 t_install_bt_backend_node(_Config) ->
     install_rvi_node("bt_backend", env(),
 		     [root(), "/priv/test_config/bt_backend.config"]).
@@ -270,6 +297,12 @@ t_start_tlsj_backend(_Config) ->
 
 t_start_tlsj_sample(_Config) ->
     generic_start("tlsj_sample").
+
+t_start_tls_backend_noverify(_Config) ->
+    generic_start("tls_backend_noverify").
+
+t_start_tls_sample_noverify(_Config) ->
+    generic_start("tls_sample_noverify").
 
 t_register_lock_service(_Config) ->
     Pid =
@@ -436,6 +469,7 @@ start_json_rpc_server(Port) ->
     Pid.
 
 handle_body(Socket, Request, Body, St) ->
+    ct:log("handle_body(Body = ~p)", [Body]),
     JSON = jsx:decode(Body),
     ct:log("Got JSON Req: ~p", [JSON]),
     case JSON of


### PR DESCRIPTION
Allows for setting up the server side to use TLS without verifying the client certs.

This will obviously be slightly less secure, but can e.g. simplify testing and development on mobile devices. The functionality will be similar to using rvi_core over TCP (but with encryption enabled).

How to use: Add `{verify, false}` to the `server_opts` of `dlink_tls_rpc`. The default is `{verify, true}`.