### PR TITLE
Converted spaces to tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,20 +145,20 @@ rpm:	rpmclean rpm_tarball
 
 install: deps compile
 ifndef STRIPPATH
-        ./scripts/rvi_install \
-                -k priv/keys/insecure_device_key.pem \
-                -r priv/certificates/insecure_root_cert.crt \
-                -d priv/certificates/insecure_device_cert.crt \
-                -c priv/credentials/insecure_credential.jwt \
-                $(DESTDIR)/opt/rvi_core
+	./scripts/rvi_install \
+		-k priv/keys/insecure_device_key.pem \
+		-r priv/certificates/insecure_root_cert.crt \
+		-d priv/certificates/insecure_device_cert.crt \
+		-c priv/credentials/insecure_credential.jwt \
+		$(DESTDIR)/opt/rvi_core
 else
-        ./scripts/rvi_install \
-                -k priv/keys/insecure_device_key.pem \
-                -r priv/certificates/insecure_root_cert.crt \
-                -d priv/certificates/insecure_device_cert.crt \
-                -c priv/credentials/insecure_credential.jwt \
-                -s $(STRIPPATH) \
-                $(DESTDIR)/opt/rvi_core
+	./scripts/rvi_install \
+		-k priv/keys/insecure_device_key.pem \
+		-r priv/certificates/insecure_root_cert.crt \
+		-d priv/certificates/insecure_device_cert.crt \
+		-c priv/credentials/insecure_credential.jwt \
+		-s $(STRIPPATH) \
+		$(DESTDIR)/opt/rvi_core
 endif
 
 	install -m 0755 -d $(DESTDIR)/etc/opt/rvi/


### PR DESCRIPTION
For some reason the tab in Makefile got replaced with spaces.
Converted them back so that make does not complain about
incorrect indentation.

Signed-off-by: Rudolf J Streif <rudolf.streif@gmail.com>