### PR TITLE
Adapt test suite to new scripts, scripts more flexible, bt not default

### DIFF
--- a/deps/setup/src/setup_gen.erl
+++ b/deps/setup/src/setup_gen.erl
@@ -83,7 +83,7 @@ help() ->
 %%                         option.
 %% * `{remove_apps, Apps}' - Remove `Apps' from the list of applications.
 %% * `{sort_app, App, Before}' - Change the sort order so that `App' comes
-%%                       before `Before'.
+%%                       before `Before'. `Before' can be either
 %% * `{include, ConfigFile}' - include options from the given file. The file
 %%                             is processed using `file:script/2'.
 %% * `{include_lib, ConfigFile}' - As above, but ConfigFile is named as with
@@ -600,7 +600,8 @@ sort_apps(Options, Apps) ->
     lists:foldl(fun({sort_app, A, Before}, Acc) ->
                         case is_in_set(A, Acc) of
                             {true, App} ->
-                                insert_before(Acc -- [App], App, Before);
+                                insert_before(Acc -- [App], App,
+                                              mk_set(Before));
                             false ->
                                 abort("Cannot re-sort ~p - not found~n", [A])
                         end;
@@ -635,6 +636,12 @@ del_from_set(As, Set) ->
                                 Acc
                         end
                 end, Set, As).
+
+%% ensure that this is a 'set' (well, at least a list)
+mk_set(Set) when is_list(Set) ->
+    Set;
+mk_set(Entry) ->
+    [Entry].
 
 is_in_set(Entry, Set) ->
     A = if is_tuple(Entry) -> element(1, Entry);

--- a/deps/setup/src/setup_gen.erl
+++ b/deps/setup/src/setup_gen.erl
@@ -83,7 +83,10 @@ help() ->
 %%                         option.
 %% * `{remove_apps, Apps}' - Remove `Apps' from the list of applications.
 %% * `{sort_app, App, Before}' - Change the sort order so that `App' comes
-%%                       before `Before'. `Before' can be either
+%%                       before `Before'. `Before' can be either an application
+%%                       name or a list of names. In the latter case, `App'
+%%                       is inserted before either of the applications in
+%%                       the list, whichever comes first.
 %% * `{include, ConfigFile}' - include options from the given file. The file
 %%                             is processed using `file:script/2'.
 %% * `{include_lib, ConfigFile}' - As above, but ConfigFile is named as with

--- a/priv/config/add_bt_apps.config
+++ b/priv/config/add_bt_apps.config
@@ -1,0 +1,5 @@
+%% -*- erlang -*-
+[
+ {add_apps, [bt, dlink_bt]},
+ {sort_app, bt, rvi_core}   %% start bt before rvi_core (not required)
+].

--- a/priv/config/rvi_common.config
+++ b/priv/config/rvi_common.config
@@ -9,8 +9,6 @@
 %% Configuration include file for rvi config files
 %%
 Out = filename:absname(proplists:get_value(outdir, OPTIONS)).
-LagerRoot = Out ++ "/log/lager".
-LagerDebugFmt = [time,"<",module,"/",line,">",message,"\n"].
 
 %% Parameters for simpler modification
 Env = fun(V, Def) ->
@@ -22,6 +20,9 @@ Env = fun(V, Def) ->
               end
       end.
 
+LogDir = Env("RVI_LOGDIR", Out ++ "/log").
+LagerRoot = LogDir ++ "/lager".
+LagerDebugFmt = [time,"<",module,"/",line,">",message,"\n"].
 LogLevel = Env("RVI_LOGLEVEL", info).
 [
  %% All erlang apps needed to fire up a node. Do not touch.
@@ -63,11 +64,9 @@ LogLevel = Env("RVI_LOGLEVEL", info).
    service_edge,
    authorize,
    schedule,
-   bt,
    dlink,
    dlink_tcp,
    dlink_tls,
-   dlink_bt,
    dlink_sms,
    proto_bert,
    proto_json,
@@ -80,7 +79,8 @@ LogLevel = Env("RVI_LOGLEVEL", info).
   [
    {setup,
     [
-     {home, Out}
+     {home, Out},
+     {log_dir, LogDir}
     ]},
    {lager,
     [

--- a/priv/test_config/backend.config
+++ b/priv/test_config/backend.config
@@ -1,14 +1,14 @@
 %% -*- erlang -*-
 {ok, CurDir} = file:get_cwd().
 [
- {include_lib, "rvi_core/priv/config/rvi_backend.config"},
- {set_env,
-  [
-   {rvi_core,
-    [{device_key, "$HOME/../../basic_backend_keys/device_key.pem"},
-     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
-     {device_cert, "$HOME/../../basic_backend_keys/device_cert.crt"},
-     {cred_dir, "$HOME/../../basic_backend_creds"}
-    ]}
-  ]}
+ {include_lib, "rvi_core/priv/config/rvi_backend.config"}
+ %% {set_env,
+ %%  [
+ %%   {rvi_core,
+ %%    [{device_key, "$HOME/../../basic_backend_keys/device_key.pem"},
+ %%     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
+ %%     {device_cert, "$HOME/../../basic_backend_keys/device_cert.crt"},
+ %%     {cred_dir, "$HOME/../../basic_backend_creds"}
+ %%    ]}
+ %%  ]}
 ].

--- a/priv/test_config/basic_backend.config
+++ b/priv/test_config/basic_backend.config
@@ -2,7 +2,6 @@
 {ok, CurDir} = file:get_cwd().
 [
  {include_lib, "rvi_core/priv/test_config/backend.config"},
- {remove_apps, [bt, dlink_bt]},
  {set_env,
   [{rvi_core,
     [

--- a/priv/test_config/basic_sample.config
+++ b/priv/test_config/basic_sample.config
@@ -1,6 +1,5 @@
 %% -*- erlang -*-
 {ok, CurDir} = file:get_cwd().
 [
- {include_lib, "rvi_core/priv/test_config/sample.config"},
- {remove_apps, [bt, dlink_bt]}
+ {include_lib, "rvi_core/priv/test_config/sample.config"}
 ].

--- a/priv/test_config/bt_backend.config
+++ b/priv/test_config/bt_backend.config
@@ -1,6 +1,7 @@
 %% -*- erlang -*-
 [
  {include_lib, "rvi_core/priv/test_config/backend.config"},
+ {include_lib, "rvi_core/priv/config/add_bt_apps.config"},
  {remove_apps, [dlink_tcp, dlink_tls]},
 
  {set_env,

--- a/priv/test_config/sample.config
+++ b/priv/test_config/sample.config
@@ -6,11 +6,11 @@
   [
    {rvi_core,
     [
-     {node_service_prefix, "jlr.com/vin/abc"},
-     {device_key, "$HOME/../../basic_sample_keys/device_key.pem"},
-     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
-     {device_cert, "$HOME/../../basic_sample_keys/device_cert.crt"},
-     {cred_dir, "$HOME/../../basic_sample_creds"}
+     {node_service_prefix, "jlr.com/vin/abc"}
+     %% {device_key, "$HOME/../../basic_sample_keys/device_key.pem"},
+     %% {root_cert, "$HOME/../../root_keys/root_cert.crt"},
+     %% {device_cert, "$HOME/../../basic_sample_keys/device_cert.crt"},
+     %% {cred_dir, "$HOME/../../basic_sample_creds"}
     ]}
   ]}
 ].

--- a/scripts/rvi_ctl.template
+++ b/scripts/rvi_ctl.template
@@ -2,7 +2,7 @@
 #
 
 #
-# Mozilla Public License, version 2.0.  The full text of the 
+# Mozilla Public License, version 2.0.  The full text of the
 # Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
 #
 #
@@ -20,7 +20,7 @@ echo ${ERL:=erl} > /dev/null
 
 
 usage() {
-    echo "Usage: $0 -d config_dir [-c config_file] -l log_dir \\" 
+    echo "Usage: $0 -d config_dir [-c config_file] -l log_dir \\"
     echo "       start|stop|console|attach|ping"
     echo
     echo "  -c config_file  Configuration file to launch rvi node with."
@@ -32,7 +32,7 @@ usage() {
     echo "  stop            Stop an rvi node previously started with 'start'."
     echo
     echo "  console         Start an rvi in foreground mode."
-    echo 
+    echo
     echo "  attach          Attach to an rvi node previously started with 'start'."
     echo
     echo "Environennt variables. Default value in paranthesis::"
@@ -42,7 +42,7 @@ usage() {
 }
 
 CONFIG_FILE=""
-SNAME=rvi
+SNAME="__RVI_NAME__"
 COOKIE=rvi_cookie
 while getopts "c:" o; do
     case "${o}" in
@@ -93,15 +93,21 @@ then
 	echo "${CONFIG_FILE} cannot be opened for reading."
 	usage
     fi
-    # 
+    #
     # Generate a config file that will end up as
     # /tmp/rvi/[cfg]/sys.config
     #
     (
-	rm -rf ${RUNDIR}
+	if [ -z "${RVI_RUNDIR}" ]
+	then
+	    RUNDIR="/tmp/rvi_${$}"
+	    rm -rf ${RUNDIR}
+	else
+	    RUNDIR=${RVI_RUNDIR}
+	fi
 	install -d --mode=0755 ${RUNDIR}
 	cd ${RUNDIR}
-	${RVI_BINDIR}/setup_gen rvi ${CONFIG_FILE} rvi
+	RVI_LOGDIR="${RVI_LOGDIR}" ${RVI_BINDIR}/setup_gen rvi ${CONFIG_FILE} rvi
     )
 
     # Did we succeed with config generation?
@@ -133,9 +139,8 @@ case "${CMD}" in
        exec ${RBI_BINDIR}/nodetool -sname ${SNAME} -setcookie ${COOKIE} ping
        ;;
 
-   attach) 
+   attach)
        exec to_erl ${RUNDIR}
        ;;
 
-esac 
-
+esac

--- a/scripts/rvi_install
+++ b/scripts/rvi_install
@@ -3,7 +3,7 @@
 # Copyright (C) 2014, Jaguar Land Rover
 #
 # This program is licensed under the terms and conditions of the
-# Mozilla Public License, version 2.0.  The full text of the 
+# Mozilla Public License, version 2.0.  The full text of the
 # Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
 #
 
@@ -12,36 +12,45 @@
 #
 #
 
-SELF_DIR=$(dirname $(readlink -f "$0"))
+# fqn : fully qualified name (e.g. realpath, but portable)
+fqn()
+{
+    echo $(cd $(dirname $1); pwd)/$(basename $1)
+}
+
+SELF_DIR=$(dirname $(fqn "$0"))
 SETUP_GEN=$SELF_DIR/setup_gen  # Ulf's kitchen sink setup utility
+TOP_DIR=$(dirname $SELF_DIR)
 
 usage() {
     cat <<EOF
 Usage:
 $0 -r root_cert -d device_cert -c credentials \\
   [-l log_dir ] [-s prefix_strip] target_dir
- 
+
 Install a built RVI system into a target directory
- 
+
 NOTE: The last component of 'taget_dir' must be named 'rvi_core'
        Example: /opt/rvi_core
- 
+
 -l log_dir      - Log directory. Default: ${target_dir}/log.
 
 -s prefix_strip - See below. Default: nil.
 
 -r root_cert    - The certificate to validate received X509 device
                   certificates and credentials.
- 
+
 -k device_key   - The PEM file containing the device key pair used
                   to sign traff
 
--d device_cert  - Certificate to use when authenticating self toward 
+-d device_cert  - Certificate to use when authenticating self toward
                   remote nodes.
 
 -c credentials  - Credentials to present to remote nodes. Can be specified
                   multiple times
-                         
+
+-n node_name    - Erlang node name. Default: rvi
+
 The created node can be started with: 'target'/rvi_ctl
 The RVI installation will rely on a separate erlang install
 to run.
@@ -54,7 +63,7 @@ PREFIX STRIPPING
   If, for example, 'target_dir' is './build/root/usr/bin', and
   'prefix_strip' is './build/root', all internal paths will
   reference '/usr/bin'.
- 
+
 ROOT CERTIFICATE
   The root certificate is used to validate remote TLS connections and
   device certificates. It is normally generated once and shared across
@@ -142,14 +151,14 @@ EXAMPLE INSTALLATION
 
   WARNING: This example installation will provide no protection
            against unauthenticated nodes, unauthorized calls, or
-           eavesdropping. Do not use in any externally facing 
+           eavesdropping. Do not use in any externally facing
            environment.
 
 EOF
- exit 1 
+ exit 1
 }
 
-if [ "${#}" = "0" ] 
+if [ "${#}" = "0" ]
 then
     usage
 fi
@@ -160,23 +169,24 @@ ROOT_CERT=""
 DEVICE_CERT=""
 DEVICE_KEY=""
 DEVICE_CRED=""
+NAME="rvi"
 
-while getopts "r:d:c:k:s:l:" o; do
+while getopts "r:d:c:k:s:l:n:" o; do
     case "${o}" in
 	r)
-	    ROOT_CERT=${OPTARG}
+	    ROOT_CERT=$(fqn ${OPTARG})
 	    ;;
 
 	d)
-	    DEVICE_CERT=${OPTARG}
+	    DEVICE_CERT=$(fqn ${OPTARG})
 	    ;;
 
 	c)
-	    DEVICE_CRED="${DEVICE_CRED} ${OPTARG}"
+	    DEVICE_CRED="${DEVICE_CRED} $(fqn ${OPTARG})"
 	    ;;
 
 	k)
-	    DEVICE_KEY=${OPTARG}
+	    DEVICE_KEY=$(fqn ${OPTARG})
 	    ;;
 
         l)
@@ -186,7 +196,9 @@ while getopts "r:d:c:k:s:l:" o; do
         s)
 	    PREFIX_STRIP=${OPTARG}
             ;;
-
+	n)
+	    NAME=${OPTARG}
+	    ;;
         *)
             usage
             ;;
@@ -213,7 +225,7 @@ then
     echo "       Example: $(dirname ${TARGET_DIR})/rvi_core"
     echo "       Run ${0} with no arguments for usage."
     exit 255
-fi 
+fi
 
 # Check that we can read the root cert
 if [ -z "${ROOT_CERT}" -o ! -r "${ROOT_CERT}" ]
@@ -267,19 +279,22 @@ then
 fi
 
 # Wipe old target dir.
-rm -rf ${TARGET_DIR} > /dev/null 2>&1 
+rm -rf ${TARGET_DIR} > /dev/null 2>&1
 
 # Create log dirs
 install -m 0755 -d ${TARGET_DIR}
 install -m 0755 -d ${LOG_DIR}
 
+TARGET_DIR=$(fqn $TARGET_DIR)
+LOG_DIR=$(fqn $LOG_DIR)
+
 # Copy over the relevant files to the target
-FILE_SET=$(find ebin components deps -name ebin -o -name priv)
-tar cf - ${FILE_SET} | (cd ${TARGET_DIR} ; tar xf - )
+(cd $TOP_DIR; FILE_SET=$(find priv ebin components deps -name ebin -o -name priv);
+tar cf - ${FILE_SET} | (cd ${TARGET_DIR} ; tar xf - ))
 
 # If we have a prefix strip (for build systems not using
 # chroot), apply it to paths.
-if [ -s "${PREFIX_STRIP}" ] 
+if [ -s "${PREFIX_STRIP}" ]
 then
     STRIP_TARGET_DIR=$(echo ${TARGET_DIR} | sed "s|^${PREFIX_STRIP}||")
     STRIP_LOG_DIR=$(echo ${LOG_DIR} | sed "s|^${PREFIX_STRIP}||")
@@ -290,7 +305,8 @@ fi
 
 # Patch rvi_ctl.template to set its ERL_LIBS path correctly.
 sed -e "s|__RVI_BINDIR__|${STRIP_TARGET_DIR}|g" \
-    -e "s|__RVI_LOGDIR__|${STRIP_LOG_DIR}|g" < scripts/rvi_ctl.template > /tmp/rvi_ctl
+    -e "s|__RVI_LOGDIR__|${STRIP_LOG_DIR}|g" \
+    -e "s|__RVI_NAME__|${NAME}|g" < $TOP_DIR/scripts/rvi_ctl.template > /tmp/rvi_ctl
 
 # Install all relevant scripts.
 install -m 0755 -d ${TARGET_DIR}/priv/certificates
@@ -302,13 +318,13 @@ install -m 0644 ${DEVICE_KEY} ${TARGET_DIR}/priv/keys/device_key.pem
 install -m 0644 ${DEVICE_CRED} ${TARGET_DIR}/priv/credentials
 install -m 0755 /tmp/rvi_ctl ${TARGET_DIR}
 rm /tmp/rvi_ctl
-install -m 0755 scripts/setup_gen ${TARGET_DIR}
-install -m 0755 rel/files/nodetool ${TARGET_DIR}
-install -m 0755 python/rvi_service.py ${TARGET_DIR}/rvi_service
-install -m 0755 python/rvi_call.py ${TARGET_DIR}/rvi_call
-install -m 0644 python/rvilib.py ${TARGET_DIR}
-install -m 0755 python/rvi_get_services.py ${TARGET_DIR}/rvi_get_services
-install -m 0755 -D priv/config/rvi_common.config ${TARGET_DIR}/priv/config/rvi_common.config
+install -m 0755 $TOP_DIR/scripts/setup_gen ${TARGET_DIR}
+install -m 0755 $TOP_DIR/rel/files/nodetool ${TARGET_DIR}
+install -m 0755 $TOP_DIR/python/rvi_service.py ${TARGET_DIR}/rvi_service
+install -m 0755 $TOP_DIR/python/rvi_call.py ${TARGET_DIR}/rvi_call
+install -m 0644 $TOP_DIR/python/rvilib.py ${TARGET_DIR}
+install -m 0755 $TOP_DIR/python/rvi_get_services.py ${TARGET_DIR}/rvi_get_services
+install -m 0755 -D $TOP_DIR/priv/config/rvi_common.config ${TARGET_DIR}/priv/config/rvi_common.config
 
 echo "RVI binary files installed under ${TARGET_DIR}"
 echo "RVI will log to ${LOG_DIR}"
@@ -319,4 +335,3 @@ echo "Stop:               ${TARGET_DIR}/rvi_ctl stop"
 echo "Start console mode: ${TARGET_DIR}/rvi_ctl -c <config_file> console"
 echo
 exit 0
-

--- a/scripts/rvi_install
+++ b/scripts/rvi_install
@@ -12,10 +12,42 @@
 #
 #
 
-# fqn : fully qualified name (e.g. realpath, but portable)
+# join two path names (avoid things like //foo or /foo/../bar)
+join()
+{
+    if [ "$1" = "/" ]
+    then
+        echo "/$2"
+    else
+        if [ "$2" = ".." ]
+        then
+            echo $(fqn $(dirname $1))
+        else
+            echo "$1/$2"
+        fi
+    fi
+}
+
+# fqn : fully qualified name
+# (e.g. realpath, but portable & works even if path doesn't exist)
 fqn()
 {
-    echo $(cd $(dirname $1); pwd)/$(basename $1)
+    if [ "$1" = "." ]
+    then
+        echo $(pwd)
+    else
+        if [ "$1" = "/" ]
+        then
+            echo "/"
+        else
+            if [ -e $1 ]
+            then
+                echo $(join $(cd $(dirname $1); pwd) $(basename $1))
+            else
+                echo $(join $(fqn $(dirname $1)) $(basename $1))
+            fi
+        fi
+    fi
 }
 
 SELF_DIR=$(dirname $(fqn "$0"))
@@ -194,7 +226,7 @@ while getopts "r:d:c:k:s:l:n:" o; do
 	    ;;
 
         s)
-	    PREFIX_STRIP=${OPTARG}
+	    PREFIX_STRIP=$(fqn ${OPTARG})
             ;;
 	n)
 	    NAME=${OPTARG}

--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -219,90 +219,86 @@ t_sample_keys_and_cert(Config) ->
     generate_sota_cred(sample, Dir, CredDir, Config).
 
 t_install_backend_node(_Config) ->
-    install_rvi_node("basic_backend", env(),
-		     [root(), "/priv/test_config/basic_backend.config"]).
+    install_backend_node("basic_backend").
 
 
 t_install_sample_node(_Config) ->
-    install_sample_node("basic_sample", "basic_sample.config").
+    install_sample_node("basic_sample").
 
 t_install_sms_backend_node(_Config) ->
-    install_rvi_node("sms_backend", env(),
-		     [root(), "/priv/test_config/sms_backend.config"]).
+    install_backend_node("sms_backend").
 
 t_install_sms_sample_node(_Config) ->
-    install_sample_node("sms_sample", "sms_sample.config").
+    install_sample_node("sms_sample").
 
 t_install_tls_backend_node(_Config) ->
-    install_rvi_node("tls_backend", env(),
-		     [root(), "/priv/test_config/tls_backend.config"]).
+    install_backend_node("tls_backend").
 
 t_install_tls_sample_node(_Config) ->
-    install_sample_node("tls_sample", "tls_sample.config").
+    install_sample_node("tls_sample").
 
 t_install_tlsj_backend_node(_Config) ->
-    install_rvi_node("tlsj_backend", env(),
-		     [root(), "/priv/test_config/tlsj_backend.config"]).
+    install_backend_node("tlsj_backend").
 
 t_install_tlsj_sample_node(_Config) ->
-    install_sample_node("tlsj_sample", "tlsj_sample.config").
+    install_sample_node("tlsj_sample").
 
 t_install_tls_backend_noverify_node(_Config) ->
-    install_rvi_node("tls_backend_noverify", env(),
-		     [root(), "/priv/test_config/tls_backend_noverify.config"]).
+    install_backend_node("tls_backend_noverify").
 
 t_install_tls_sample_noverify_node(_Config) ->
-    install_sample_node("tls_sample_noverify", "tls_sample_noverify.config").
+    install_sample_node("tls_sample_noverify").
 
 t_install_bt_backend_node(_Config) ->
-    install_rvi_node("bt_backend", env(),
-		     [root(), "/priv/test_config/bt_backend.config"]).
+    install_backend_node("bt_backend").
 
 t_install_bt_sample_node(_Config) ->
-    install_sample_node("bt_sample", "bt_sample.config").
+    install_sample_node("bt_sample").
 
-generic_start(Name) ->
+start_backend(Name) -> generic_start(backend, Name).
+start_sample (Name) -> generic_start(sample , Name).
+
+generic_start(Type, Name) ->
+    {ok,Cwd} = file:get_cwd(),
     F = filename:join([".", Name, "start_me.sh"]),
-    Cmd = [env(),
-	   " ./", Name, "/rvi.sh",
-	   " -s ", Name,
-	   " -l ./", Name, "/rvi/log",
-	   " -d ./", Name,
-	   " -c ./", Name, "/priv/test_config/", Name, ".config",
-	   " $1"],
+    Cmd = [env(Type),
+	   " RVI_RUNDIR=", filename:join(Cwd, Name),
+	   " ./", Name, "/rvi_core/rvi_ctl",
+	   " -c ./", Name, "/rvi_core/priv/test_config/", Name, ".config",
+	   " $*"],
     ok = save_cmd(F, Cmd),
-    cmd([F, " start"]),
+    cmd(["sh -x ", F, " start"]),
     await_started(Name).
 
 t_start_basic_backend(_Config) ->
-    generic_start("basic_backend").
+    start_backend("basic_backend").
 
 t_start_basic_sample(_Config) ->
-    generic_start("basic_sample").
+    start_sample("basic_sample").
 
 t_start_bt_backend(_Config) ->
-    generic_start("bt_backend").
+    start_backend("bt_backend").
 
 t_start_bt_sample(_Config) ->
-    generic_start("bt_sample").
+    start_sample("bt_sample").
 
 t_start_tls_backend(_Config) ->
-    generic_start("tls_backend").
+    start_backend("tls_backend").
 
 t_start_tls_sample(_Config) ->
-    generic_start("tls_sample").
+    start_sample("tls_sample").
 
 t_start_tlsj_backend(_Config) ->
-    generic_start("tlsj_backend").
+    start_backend("tlsj_backend").
 
 t_start_tlsj_sample(_Config) ->
-    generic_start("tlsj_sample").
+    start_sample("tlsj_sample").
 
 t_start_tls_backend_noverify(_Config) ->
-    generic_start("tls_backend_noverify").
+    start_backend("tls_backend_noverify").
 
 t_start_tls_sample_noverify(_Config) ->
-    generic_start("tls_sample_noverify").
+    start_sample("tls_sample_noverify").
 
 t_register_lock_service(_Config) ->
     Pid =
@@ -706,6 +702,15 @@ ensure_dir(Dir) ->
 env() ->
     "RVI_LOGLEVEL=debug RVI_MYIP=127.0.0.1 RVI_BACKEND=127.0.0.1".
 
+env(backend) ->
+    env();
+env(sample) ->
+    [env(),
+     " RVI_BACKEND=127.0.0.1 RVI_PORT=9000"
+     " RVI_MY_NODE_ADDR=127.0.0.1:9000"].
+
+
+
 root() ->
     code:lib_dir(rvi_core).
 
@@ -724,17 +729,27 @@ service_edge("sample" ) -> "http://localhost:9001".
 rvi_log_addr("backend") -> "http://localhost:8809";
 rvi_log_addr("sample" ) -> "http://localhost:9009".
 
-install_rvi_node(Name, Env, _ConfigF) ->
+install_backend_node(Name) ->
+    install_rvi_node(backend, Name).
+
+install_sample_node(Name) ->
+    install_rvi_node(sample, Name).
+
+install_rvi_node(Type, Name) ->
     Root = code:lib_dir(rvi_core),
     Scripts = filename:join(Root, "scripts"),
     ct:log("Root = ~p", [Root]),
     Cmd = lists:flatten(
-	    [Env, " ", Scripts, "/rvi_install.sh ./", Name]),
-
+	    ["sh -x ", Scripts, "/rvi_install",
+	     " -r ", filename:join(root_keys(), "root_cert.crt"),
+	     " -d basic_backend_keys/device_cert.crt",
+	     " -k basic_backend_keys/device_key.pem",
+	     " -n ", Name,
+	     creds(Type),
+	     " ", Name, "/rvi_core"]),
     ct:log("Cmd = `~s`", [Cmd]),
     Res = cmd(Cmd),
     ct:log("install_rvi_node/1 -> ~p", [Res]),
-
 
     Res1 = cmd(lists:flatten(["install -d --mode 0755 ./", Name])),
     ct:log("install_rvi_node/2 -> ~p", [Res1]),
@@ -744,17 +759,12 @@ install_rvi_node(Name, Env, _ConfigF) ->
 
     Res2.
 
-install_sample_node(Name, ConfigF) ->
-    Env = [env(),
-	   " RVI_BACKEND=127.0.0.1 RVI_PORT=9000"
-	   " RVI_MY_NODE_ADDR=127.0.0.1:9000"],
-    install_rvi_node(Name, Env,
-		     [root(), "/priv/test_config/", ConfigF]).
-
-%% in_priv_dir(F, Cfg) ->
-%%     %% PrivDir = ?config(priv_dir, Cfg),
-%%     %% in_dir(PrivDir, F, Cfg).
-%%     F(Cfg).
+creds(backend) ->
+    [" -c basic_backend_creds/backend_cred.jwt"
+     " -c basic_backend_creds/sota_backend_cred.jwt"];
+creds(sample) ->
+    [" -c basic_sample_creds/lock_cred.jwt"
+     " -c basic_sample_creds/sota_cred.jwt"].
 
 cmd(C) ->
     cmd(C, []).
@@ -896,7 +906,8 @@ no_errors(Dirs, PDir) ->
     ct:log("Will check errors in ~p", [Dirs]),
     true = lists:all(
 	     fun(D) ->
-		     no_errors_(filename:join([PDir, D, "rvi", "log", "lager"]), D)
+		     no_errors_(filename:join([PDir, D, "rvi_core",
+					       "log", "lager"]), D)
 	     end, Dirs),
     ok.
 
@@ -913,6 +924,6 @@ log_is_empty(Log, F, Name) ->
 	    ct:log("~s: ~s is not empty:~n~s", [Name, F, Content]),
 	    false;
 	{error, Reason} ->
-	    ct:log("~s: Cannot read log ~s (~p)", [Name, F, Reason]),
+	    ct:log("~s: Cannot read log ~s (~p)", [Name, Log, Reason]),
 	    false
     end.


### PR DESCRIPTION
- rvi_install & rvi_ctl adapted so they can be run from different directories
- ensure that RVI_LOGDIR is respected consistently
- RVI_RUNDIR allows for specifying where the boot scripts are stored
- bt apps excluded by default, can be put back in through config if needed