### PR TITLE
use the generated creds in test suite

### DIFF
--- a/priv/test_config/backend.config
+++ b/priv/test_config/backend.config
@@ -1,14 +1,14 @@
 %% -*- erlang -*-
 {ok, CurDir} = file:get_cwd().
 [
- {include_lib, "rvi_core/priv/config/rvi_backend.config"}
- %% {set_env,
- %%  [
- %%   {rvi_core,
- %%    [{device_key, "$HOME/../../basic_backend_keys/device_key.pem"},
- %%     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
- %%     {device_cert, "$HOME/../../basic_backend_keys/device_cert.crt"},
- %%     {cred_dir, "$HOME/../../basic_backend_creds"}
- %%    ]}
- %%  ]}
+ {include_lib, "rvi_core/priv/config/rvi_backend.config"},
+ {set_env,
+  [
+   {rvi_core,
+    [{device_key, "$HOME/../../basic_backend_keys/device_key.pem"},
+     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
+     {device_cert, "$HOME/../../basic_backend_keys/device_cert.crt"},
+     {cred_dir, "$HOME/../../basic_backend_creds"}
+    ]}
+  ]}
 ].

--- a/priv/test_config/sample.config
+++ b/priv/test_config/sample.config
@@ -6,11 +6,11 @@
   [
    {rvi_core,
     [
-     {node_service_prefix, "jlr.com/vin/abc"}
-     %% {device_key, "$HOME/../../basic_sample_keys/device_key.pem"},
-     %% {root_cert, "$HOME/../../root_keys/root_cert.crt"},
-     %% {device_cert, "$HOME/../../basic_sample_keys/device_cert.crt"},
-     %% {cred_dir, "$HOME/../../basic_sample_creds"}
+     {node_service_prefix, "jlr.com/vin/abc"},
+     {device_key, "$HOME/../../basic_sample_keys/device_key.pem"},
+     {root_cert, "$HOME/../../root_keys/root_cert.crt"},
+     {device_cert, "$HOME/../../basic_sample_keys/device_cert.crt"},
+     {cred_dir, "$HOME/../../basic_sample_creds"}
     ]}
   ]}
 ].


### PR DESCRIPTION
The test suite has been using the default creds instead of the ones generated for the purpose.