### PR TITLE
Uw add bt in bt sample

### DIFF
--- a/priv/test_config/bt_sample.config
+++ b/priv/test_config/bt_sample.config
@@ -1,6 +1,7 @@
 %% -*- erlang -*-
 [
  {include_lib, "rvi_core/priv/test_config/sample.config"},
+ {include_lib, "rvi_core/priv/config/add_bt_apps.config"},
  {remove_apps, [dlink_tcp, dlink_tls]},
  {set_env,
   [

--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -723,10 +723,11 @@ env() ->
     "RVI_LOGLEVEL=debug RVI_MYIP=127.0.0.1 RVI_BACKEND=127.0.0.1".
 
 env(backend) ->
-    env();
+    [env(), " RVI_MYPORT=8800",
+     " RVI_MY_NODE_ADDR=127.0.0.1:8800"];
 env(sample) ->
     [env(),
-     " RVI_BACKEND=127.0.0.1 RVI_PORT=9000"
+     " RVI_BACKEND=127.0.0.1"
      " RVI_MY_NODE_ADDR=127.0.0.1:9000"].
 
 

--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -141,9 +141,9 @@ groups() ->
        t_register_lock_service,
        t_register_sota_service,
        t_call_lock_service,
-       %% t_call_sota_service,
-       %% t_multicall_sota_service,
-       %% t_remote_call_lock_service,
+       t_call_sota_service,
+       t_multicall_sota_service,
+       t_remote_call_lock_service,
        t_no_errors
       ]}
     ].


### PR DESCRIPTION
(Based on PR #93)
One of the test configs for BT didn't add the bt apps (some bt tests were temporarily disabled since they were failing). This PR adds the line that includes the bt apps, and re-enables those test cases.