### PR TITLE
Uw tls options

### DIFF
--- a/components/dlink_tls/src/dlink_tls_conn.erl
+++ b/components/dlink_tls/src/dlink_tls_conn.erl
@@ -427,7 +427,10 @@ do_upgrade(Sock, server, CompSpec) ->
 
 tls_opts(Role, CompSpec) ->
     {ok, ServerOpts} = get_module_config(server_opts, [], CompSpec),
-    TlsOpts = proplists:get_value(tls_opts, ServerOpts, []),
+    TlsOpts0 = proplists:get_value(tls_opts, ServerOpts, []),
+    TlsOpts = TlsOpts0 ++
+        [{reuse_sessions, false}
+         || not lists:keymember(reuse_sessions, 1, TlsOpts0)],
     ?debug("TlsOpts = ~p", [TlsOpts]),
     Opt = fun(K) -> opt(K, TlsOpts,
                         fun() ->

--- a/components/rvi_common/src/rvi_common.erl
+++ b/components/rvi_common/src/rvi_common.erl
@@ -214,8 +214,8 @@ notification(Component,
 	    send_json_notification(URL, atom_to_binary(Function, latin1),  JSONArg),
 	    ok;
 	{ error, _ } = Error ->
-	    ?warning("get_module_type(~p,~p,~p) -> ~p",
-		     [Component, Module, CompSpec, Error]),
+	    ?debug("get_module_type(~p,~p,~p) -> ~p",
+		   [Component, Module, CompSpec, Error]),
 	    %% ignore
 	    ok
     end.

--- a/priv/test_config/tls_backend.config
+++ b/priv/test_config/tls_backend.config
@@ -8,7 +8,10 @@
      { [routing_rules, ""], [{proto_msgpack_rpc, dlink_tls_rpc}] },
      { [components, data_link], [{dlink_tls_rpc, gen_server,
 				  [{server_opts, [{port, 8807},
-						  {ping_interval,500}]}]}]},
+						  {ping_interval,500},
+						  {tls_opts,
+						   [{reuse_sessions, false}]}
+						 ]}]}]},
      { [components, protocol], [{proto_msgpack_rpc, gen_server, []}] }
     ]}
   ]}

--- a/priv/test_config/tls_backend_noverify.config
+++ b/priv/test_config/tls_backend_noverify.config
@@ -8,8 +8,9 @@
      { [routing_rules, ""], [{proto_msgpack_rpc, dlink_tls_rpc}] },
      { [components, data_link], [{dlink_tls_rpc, gen_server,
 				  [{server_opts, [{port, 8807},
-						  {verify, false},
-						  {ping_interval,500}]}]}]},
+						  {ping_interval,500},
+						  {tls_opts,
+						   [{verify, false}]}]}]}]},
      { [components, protocol], [{proto_msgpack_rpc, gen_server, []}] }
     ]}
   ]}

--- a/priv/test_config/tls_sample_noverify.config
+++ b/priv/test_config/tls_sample_noverify.config
@@ -8,7 +8,6 @@
      { [routing_rules, ""], [{proto_msgpack_rpc, dlink_tls_rpc}] },
      { [components, data_link], [{dlink_tls_rpc, gen_server,
 				  [{server_opts, [{port, 9007},
-%						  {verify, false},
 						  {ping_interval,500}]},
 				   {persistent_connections,
 				    ["localhost:8807"]}]}]},


### PR DESCRIPTION
This PR makes `dlink_tls` reject session reuse by default. This is mainly because the iOS SSL stack has no good way to disable session reuse from the client side.

The reason to disable session reuse (i.e. the SSL cache) in the first place is that the RVI SDK wants to get the peer certificate, and having the application cache it from the first connect seems problematic.

The PR also makes it possible to pass custom TLS options to the ssl_connect/ssl_accept call, by adding `{tls_opts, [...]}` to the dlink_tls_rpc server opts.

Tested with the iOS client. The Android client already creates a new session each time.