### PR TITLE
Uw node prefix api

### DIFF
--- a/components/service_edge/src/service_edge_rpc.erl
+++ b/components/service_edge/src/service_edge_rpc.erl
@@ -300,6 +300,12 @@ handle_ws_json_rpc(WSock, <<"unregister_service">>, Params, _Arg ) ->
     gen_server:call(?SERVER, { rvi, unregister_local_service, [ SvcName ]}),
     { ok, [ { status, rvi_common:json_rpc_status(ok)} ]};
 
+handle_ws_json_rpc(WSock, <<"get_node_service_prefix">>, [], _Arg) ->
+    ?debug("websocket_get_node_service_prefix(~p)", [WSock]),
+    { ok, [ { status, rvi_common:json_rpc_status(ok) },
+	    { node_service_prefix, rvi_common:local_service_prefix() },
+	    { method, <<"get_node_service_prefix">> } ]};
+
 handle_ws_json_rpc(_Ws , <<"get_available_services">>, _Params, _Arg ) ->
     ?debug("service_edge_rpc:websocket_get_available()"),
     [ ok, Services ] =
@@ -343,6 +349,10 @@ handle_rpc(<<"unregister_service">>, Args) ->
 	   { method, <<"unregister_service">>}
 	 ]};
 
+handle_rpc(<<"get_node_service_prefix">>, []) ->
+    { ok, [ { status, rvi_common:json_rpc_status(ok) },
+	    { node_service_prefix, rvi_common:local_service_prefix() },
+	    { method, <<"get_node_service_prefix">> } ]};
 
 handle_rpc(<<"get_available_services">>, _Args) ->
     [ Status, Services ] = gen_server:call(?SERVER, { rvi, get_available_services, []}),

--- a/components/service_edge/src/service_edge_rpc.erl
+++ b/components/service_edge/src/service_edge_rpc.erl
@@ -300,11 +300,9 @@ handle_ws_json_rpc(WSock, <<"unregister_service">>, Params, _Arg ) ->
     gen_server:call(?SERVER, { rvi, unregister_local_service, [ SvcName ]}),
     { ok, [ { status, rvi_common:json_rpc_status(ok)} ]};
 
-handle_ws_json_rpc(WSock, <<"get_node_service_prefix">>, [], _Arg) ->
+handle_ws_json_rpc(WSock, <<"get_node_service_prefix">>, Params, _Arg) ->
     ?debug("websocket_get_node_service_prefix(~p)", [WSock]),
-    { ok, [ { status, rvi_common:json_rpc_status(ok) },
-	    { node_service_prefix, rvi_common:local_service_prefix() },
-	    { method, <<"get_node_service_prefix">> } ]};
+    get_node_service_prefix_(Params);
 
 handle_ws_json_rpc(_Ws , <<"get_available_services">>, _Params, _Arg ) ->
     ?debug("service_edge_rpc:websocket_get_available()"),
@@ -349,10 +347,9 @@ handle_rpc(<<"unregister_service">>, Args) ->
 	   { method, <<"unregister_service">>}
 	 ]};
 
-handle_rpc(<<"get_node_service_prefix">>, []) ->
-    { ok, [ { status, rvi_common:json_rpc_status(ok) },
-	    { node_service_prefix, rvi_common:local_service_prefix() },
-	    { method, <<"get_node_service_prefix">> } ]};
+handle_rpc(<<"get_node_service_prefix">>, Params) ->
+    ?debug("get_node_service_prefix", []),
+    get_node_service_prefix_(Params);
 
 handle_rpc(<<"get_available_services">>, _Args) ->
     [ Status, Services ] = gen_server:call(?SERVER, { rvi, get_available_services, []}),
@@ -379,6 +376,26 @@ handle_rpc(Other, _Args) ->
     ?warning("service_edge_rpc:handle_rpc(~p): unknown command", [ Other ]),
     {ok,[ { status, rvi_common:json_rpc_status(invalid_command)} ]}.
 
+
+get_node_service_prefix_(Params) ->
+    Prefix = rvi_common:local_service_prefix(),
+    [UUID | _ ] = re:split(Prefix, <<"/">>, [{return, binary}]),
+    GoodRes = fun(R) ->
+		      { ok, [ { status, rvi_common:json_rpc_status(ok) },
+			      { node_service_prefix, R },
+			      { method, <<"get_node_service_prefix">> } ]}
+	      end,
+    case rvi_common:get_json_element(["full"], Params) of
+	{ok, Full} when Full == true; Full == 1 ->
+	    GoodRes(Prefix);
+	{error, _} ->
+	    GoodRes(Prefix);
+	{ok, Full} when Full == false; Full == 0 ->
+	    GoodRes(UUID);
+	_ ->
+	    { ok, [ { status, rvi_common:json_rpc_status(invalid_command) },
+		    { method, <<"get_node_service_prefix">> } ] }
+    end.
 
 handle_notification(<<"service_available">>, Args) ->
     {ok, SvcName} = rvi_common:get_json_element([<<"service">>], Args),

--- a/test/rvi_core_SUITE.erl
+++ b/test/rvi_core_SUITE.erl
@@ -42,6 +42,7 @@
     t_call_sota_service/1,
     t_multicall_sota_service/1,
     t_remote_call_lock_service/1,
+    t_get_node_service_prefix/1,
     t_check_rvi_log/1,
     t_no_errors/1
    ]).
@@ -94,6 +95,7 @@ groups() ->
        t_call_sota_service,
        t_multicall_sota_service,
        t_remote_call_lock_service,
+       t_get_node_service_prefix,
        t_no_errors
       ]},
      {test_run_tls, [],
@@ -106,6 +108,7 @@ groups() ->
        t_remote_call_lock_service,
        t_call_sota_service,
        t_multicall_sota_service,
+       t_get_node_service_prefix,
        t_check_rvi_log,
        t_no_errors
       ]},
@@ -131,6 +134,7 @@ groups() ->
        t_remote_call_lock_service,
        t_call_sota_service,
        t_multicall_sota_service,
+       t_get_node_service_prefix,
        t_check_rvi_log,
        t_no_errors
       ]},
@@ -144,6 +148,7 @@ groups() ->
        t_call_sota_service,
        t_multicall_sota_service,
        t_remote_call_lock_service,
+       t_get_node_service_prefix,
        t_no_errors
       ]}
     ].
@@ -362,6 +367,43 @@ flush_reqs([{Pid, Ref}|T]) ->
 flush_reqs([]) ->
     ok.
 
+t_get_node_service_prefix(Config) ->
+    get_node_service_prefix_("backend", Config),
+    get_short_node_service_prefix_("backend", Config),
+    get_node_service_prefix_("sample", Config),
+    get_short_node_service_prefix_("sample", Config).
+
+get_node_service_prefix_(Node, _Config) ->
+    Reply = json_rpc_request(
+	      service_edge(Node),
+	      <<"get_node_service_prefix">>,
+	      []),
+    ct:log("get_node_service_prefix (~s) -> ~p", [Node, Reply]),
+    Result = node_prefix_result(Reply),
+    ct:log("Result = ~p", [Result]),
+    case Node of
+	"sample"	-> <<"jlr.com/vin/abc/">> = Result;
+	"backend"	-> <<"genivi.org/backend/">> = Result
+    end,
+    ok.
+
+get_short_node_service_prefix_(Node, _Config) ->
+    Reply = json_rpc_request(
+	      service_edge(Node),
+	      <<"get_node_service_prefix">>,
+	      [{<<"full">>, false}]),
+    ct:log("get_short_node_service_prefix (~s) -> ~p", [Node, Reply]),
+    Result = node_prefix_result(Reply),
+    ct:log("Result = ~p", [Result]),
+    case Node of
+	"sample"	-> <<"jlr.com">> = Result;
+	"backend"	-> <<"genivi.org">> = Result
+    end,
+    ok.
+
+node_prefix_result(Res) ->
+    proplists:get_value(<<"node_service_prefix">>,
+			proplists:get_value(<<"result">>, Res), []).
 
 call_sota_service_(RegName, Data) ->
     {Mega, Secs, _} = os:timestamp(),


### PR DESCRIPTION
This PR adds a Service Edge RPC: "get_node_service_prefix"
Args: `[{"full": true | false}]` are optional; default is `[{"full": true}]`
If `"full" = true`, the whole node service prefix is returned; otherwise, only the organization domain name is returned.