### PR TITLE
Change all paths from /opt to /usr/share

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ ifndef STRIPPATH
 		-r priv/certificates/insecure_root_cert.crt \
 		-d priv/certificates/insecure_device_cert.crt \
 		-c priv/credentials/insecure_credential.jwt \
-		$(DESTDIR)/opt/rvi_core
+		$(DESTDIR)/usr/share/rvi_core
 else
 	./scripts/rvi_install \
 		-k priv/keys/insecure_device_key.pem \
@@ -180,8 +180,8 @@ else
 		-d priv/certificates/insecure_device_cert.crt \
 		-c priv/credentials/insecure_credential.jwt \
 		-s $(STRIPPATH) \
-		$(DESTDIR)/opt/rvi_core
+		$(DESTDIR)/usr/share/rvi_core
 endif
 
-	install -m 0755 -d $(DESTDIR)/etc/opt/rvi/
-	install -m 0644 priv/config/rvi_sample.config $(DESTDIR)/etc/opt/rvi/rvi_sample.config
+	install -m 0755 -d $(DESTDIR)/etc/rvi/
+	install -m 0644 priv/config/rvi_sample.config $(DESTDIR)/etc/rvi/rvi_sample.config

--- a/debian_template/README.Debian
+++ b/debian_template/README.Debian
@@ -3,8 +3,8 @@ rvi for Debian
 
 Will rely on existing Erlang installation to work.
 
-We will copy out the Erlang VM BEAM files to /opt/rvi and the configuration files to /etc/opt/rvi
+We will copy out the Erlang VM BEAM files to /usr/share/rvi and the configuration files to /etc/rvi
 
-/opt/rvi/rvi.sh is the main control program.
+/usr/share/rvi/rvi.sh is the main control program.
 
  -- Magnus Feuer <mfeuer@jaguarlandrover.com>  Fri, 27 Nov 2015 15:34:39 -0800

--- a/packaging/rvi_core.spec
+++ b/packaging/rvi_core.spec
@@ -28,16 +28,16 @@ make compile
 ./scripts/setup_rvi_node.sh -n rvi_tizen -c ./packaging/tizen.config
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION
-cp -ar rel/rvi_tizen $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION
-cp -ar python $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION
+mkdir -p $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION
+cp -ar rel/rvi_tizen $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION
+cp -ar python $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION
 mkdir -p $RPM_BUILD_ROOT/usr/lib/systemd/system/
 mkdir -p $RPM_BUILD_ROOT/etc/systemd/system/multi-user.target.wants/
 install ./scripts/rvi.service $RPM_BUILD_ROOT/usr/lib/systemd/system/rvi.service 
 ln -fsr $RPM_BUILD_ROOT/usr/lib/systemd/system/rvi.service \
     $RPM_BUILD_ROOT/etc/systemd/system/multi-user.target.wants/rvi.service
-ln -fsr $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION/releases/$RPM_PACKAGE_VERSION/sys.config \
-       $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION/sys.config 
+ln -fsr $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION/releases/$RPM_PACKAGE_VERSION/sys.config \
+       $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION/sys.config 
 mkdir -p $RPM_BUILD_ROOT/home/app/content/Documents
 echo "default_vin" > $RPM_BUILD_ROOT/home/app/content/Documents/vin
 
@@ -50,4 +50,4 @@ rm -rf $RPM_BUILD_ROOT
 %attr(644,app,users) /home/app/content/Documents/vin
 /usr/lib/systemd/system/rvi.service 
 /etc/systemd/system/multi-user.target.wants/rvi.service
-/opt/rvi-0.5.1
+/usr/share/rvi-0.5.1

--- a/priv/config/rvi_yocto.config
+++ b/priv/config/rvi_yocto.config
@@ -144,7 +144,7 @@ LogLevel = Env("RVI_LOGLEVEL", notice).
      %% value unless all services add a system-wide unique name
      %% to it.
      %%
-     { node_service_prefix, "$rvi_file(/etc/opt/rvi/device_id,genivi.org/node/default_id)/"},
+     { node_service_prefix, "$rvi_file(/etc/rvi/device_id,genivi.org/node/default_id)/"},
 
      %% Routing rules determine how to get a message targeting a specific
      %% service to its destination.

--- a/raspbian_template/README.Debian
+++ b/raspbian_template/README.Debian
@@ -3,8 +3,8 @@ rvi for Debian
 
 Will rely on existing Erlang installation to work.
 
-We will copy out the Erlang VM BEAM files to /opt/rvi and the configuration files to /etc/opt/rvi
+We will copy out the Erlang VM BEAM files to /usr/share/rvi and the configuration files to /etc/rvi
 
-/opt/rvi/rvi.sh is the main control program.
+/usr/share/rvi/rvi.sh is the main control program.
 
  -- Magnus Feuer <mfeuer@jaguarlandrover.com>  Fri, 27 Nov 2015 15:34:39 -0800

--- a/rpm/SPECS/rvi-0.5.1.spec
+++ b/rpm/SPECS/rvi-0.5.1.spec
@@ -30,7 +30,7 @@ make compile
 
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION
+mkdir -p $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION
 cp -ar rel/rvi-$RPM_PACKAGE_VERSION $RPM_BUILD_ROOT/opt/
 
 # Create a standard debian setup for start/stop.
@@ -52,8 +52,8 @@ ln -fsr $RPM_BUILD_ROOT/etc/init.d/rvi $RPM_BUILD_ROOT/etc/rc5.d/S50-rvi
 ln -fsr $RPM_BUILD_ROOT/etc/init.d/rvi $RPM_BUILD_ROOT/etc/rc6.d/K20-rvi
 
 # Make global config file easier to access.
-ln -fsr $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION/releases/1/sys.config \
-       $RPM_BUILD_ROOT/opt/rvi-$RPM_PACKAGE_VERSION/sys.config 
+ln -fsr $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION/releases/1/sys.config \
+       $RPM_BUILD_ROOT/usr/share/rvi-$RPM_PACKAGE_VERSION/sys.config 
 %post
 
 %clean
@@ -69,4 +69,4 @@ rm -rf $RPM_BUILD_ROOT
 /etc/rc4.d
 /etc/rc5.d
 /etc/rc6.d
-/opt/rvi-0.5.1
+/usr/share/rvi-0.5.1

--- a/scripts/rvi_install
+++ b/scripts/rvi_install
@@ -63,9 +63,9 @@ $0 -r root_cert -d device_cert -c credentials \\
 Install a built RVI system into a target directory
 
 NOTE: The last component of 'taget_dir' must be named 'rvi_core'
-       Example: /opt/rvi_core
+       Example: /usr/share/rvi_core
 
--l log_dir      - Log directory. Default: ${target_dir}/log.
+-l log_dir      - Log directory. Default: /run/log/rvi_core (not permanent)
 
 -s prefix_strip - See below. Default: nil.
 
@@ -178,7 +178,7 @@ EXAMPLE INSTALLATION
      -r priv/certificates/insecure_root_cert.crt \\
      -d priv/certificates/insecure_device_cert.crt \\
      -c priv/credentials/insecure_credential.jwt \\
-     /opt/rvi_core
+     /usr/share/rvi_core
 
 
   WARNING: This example installation will provide no protection
@@ -307,7 +307,7 @@ done
 #
 if [ -z "${LOG_DIR}" ]
 then
-    LOG_DIR=${TARGET_DIR}/log
+    LOG_DIR=/run/log/rvi_core
 fi
 
 # Wipe old target dir.

--- a/ubuntu_template/README.Debian
+++ b/ubuntu_template/README.Debian
@@ -3,8 +3,8 @@ rvi for Debian
 
 Will rely on existing Erlang installation to work.
 
-We will copy out the Erlang VM BEAM files to /opt/rvi and the configuration files to /etc/opt/rvi
+We will copy out the Erlang VM BEAM files to /usr/share/rvi and the configuration files to /etc/rvi
 
-/opt/rvi/rvi.sh is the main control program.
+/usr/share/rvi/rvi.sh is the main control program.
 
  -- Magnus Feuer <mfeuer@jaguarlandrover.com>  Fri, 27 Nov 2015 15:34:39 -0800

--- a/yocto_template/rvi.init
+++ b/yocto_template/rvi.init
@@ -23,13 +23,13 @@ export PATH="/bin/:/usr/bin:/sbin:/usr/sbin"
 
 set -e 
 
-DAEMON_PATH="/opt/rvi_core"
+DAEMON_PATH="/usr/share/rvi_core"
 DAEMON_NAME="rvi"
 
 case "$1" in
   start)
         echo -n "Starting $DAEMON_NAME: "
-        $DAEMON_PATH/rvi_ctl -c /etc/opt/rvi/rvi.config start
+        $DAEMON_PATH/rvi_ctl -c /etc/rvi/rvi.config start
         RETVAL=$?
         if [ $RETVAL -eq 0 ] ; then
             echo "OK"

--- a/yocto_template/rvi.service
+++ b/yocto_template/rvi.service
@@ -4,12 +4,12 @@ Description=Remote Vehicle Interaction Service
 Wants=network-online.target
 
 [Service]
-Environment="HOME=/opt/rvi_core"
+Environment="HOME=/usr/share/rvi_core"
 Type=forking
 StandardOutput=journal
 StandardError=journal
-ExecStart=/opt/rvi_core/rvi_ctl -c /etc/opt/rvi/rvi.config start
-ExecStop=/opt/rvi_core/rvi_ctl stop
+ExecStart=/usr/share/rvi_core/rvi_ctl -c /etc/rvi/rvi.config start
+ExecStop=/usr/share/rvi_core/rvi_ctl stop
 GuessMainPID=yes
 RemainAfterExit=yes
 


### PR DESCRIPTION
(Sorry, I pushed the branch on here instead of on a fork.  But that can be cleaned up easily...)

Change all paths from /opt to /usr/share

/opt can't be used in an normal OS-tree compatible layout - program files should now reside under /usr.

/etc/opt/<rvi config files> changed to remove opt which looks odd there anyway: --> /etc/rvi/<config files>.


